### PR TITLE
W3 basic task feat unit test

### DIFF
--- a/src/main/java/kr/hhplus/be/server/adapter/cache/InMemoryCacheAdapter.java
+++ b/src/main/java/kr/hhplus/be/server/adapter/cache/InMemoryCacheAdapter.java
@@ -4,35 +4,34 @@ import kr.hhplus.be.server.domain.port.cache.CachePort;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
 
 @Component
 public class InMemoryCacheAdapter implements CachePort {
-    
+
     private final Map<String, Object> cache = new ConcurrentHashMap<>();
-    
+
     @Override
-    public <T> Optional<T> get(String key, Class<T> type) {
+    public <T> T get(String key, Class<T> type, Supplier<T> supplier) {
         Object value = cache.get(key);
         if (value != null && type.isInstance(value)) {
-            return Optional.of(type.cast(value));
+            return type.cast(value);
         }
-        return Optional.empty();
+        T suppliedValue = supplier.get();
+        if (suppliedValue != null) {
+            cache.put(key, suppliedValue);
+        }
+        return suppliedValue;
     }
-    
+
     @Override
-    public void set(String key, Object value) {
+    public void put(String key, Object value, int ttlSeconds) {
         cache.put(key, value);
     }
-    
+
     @Override
-    public void delete(String key) {
+    public void evict(String key) {
         cache.remove(key);
-    }
-    
-    @Override
-    public boolean exists(String key) {
-        return cache.containsKey(key);
     }
 } 

--- a/src/main/java/kr/hhplus/be/server/adapter/storage/inmemory/InMemoryBalanceRepository.java
+++ b/src/main/java/kr/hhplus/be/server/adapter/storage/inmemory/InMemoryBalanceRepository.java
@@ -2,6 +2,7 @@ package kr.hhplus.be.server.adapter.storage.inmemory;
 
 import kr.hhplus.be.server.domain.entity.Balance;
 import kr.hhplus.be.server.domain.port.storage.BalanceRepositoryPort;
+import kr.hhplus.be.server.domain.entity.User;
 import org.springframework.stereotype.Repository;
 
 import java.math.BigDecimal;
@@ -11,26 +12,17 @@ import java.util.concurrent.ConcurrentHashMap;
 
 @Repository
 public class InMemoryBalanceRepository implements BalanceRepositoryPort {
-    
+
     private final Map<Long, Balance> balances = new ConcurrentHashMap<>();
-    
+
     @Override
-    public Optional<Balance> findByUserId(Long userId) {
-        return Optional.ofNullable(balances.get(userId));
+    public Optional<Balance> findByUser(User user) {
+        return balances.values().stream().filter(balance -> balance.getUser().equals(user)).findFirst();
     }
-    
+
     @Override
     public Balance save(Balance balance) {
-        balances.put(balance.getUser().getId(), balance);
-        return balance;
-    }
-    
-    @Override
-    public Balance updateAmount(Long userId, BigDecimal amount) {
-        Balance balance = balances.get(userId);
-        if (balance != null) {
-            // TODO: 실제 업데이트 로직 구현
-        }
+        balances.put(balance.getId(), balance);
         return balance;
     }
 } 

--- a/src/main/java/kr/hhplus/be/server/adapter/storage/inmemory/InMemoryCouponHistoryRepository.java
+++ b/src/main/java/kr/hhplus/be/server/adapter/storage/inmemory/InMemoryCouponHistoryRepository.java
@@ -12,29 +12,27 @@ import java.util.concurrent.ConcurrentHashMap;
 
 @Repository
 public class InMemoryCouponHistoryRepository implements CouponHistoryRepositoryPort {
-    
+
     private final Map<Long, CouponHistory> couponHistories = new ConcurrentHashMap<>();
-    
+
     @Override
-    public Optional<CouponHistory> findById(Long id) {
-        return Optional.ofNullable(couponHistories.get(id));
+    public boolean existsByUserAndCoupon(kr.hhplus.be.server.domain.entity.User user, kr.hhplus.be.server.domain.entity.Coupon coupon) {
+        return couponHistories.values().stream()
+                .anyMatch(history -> history.getUser().equals(user) && history.getCoupon().equals(coupon));
     }
-    
-    @Override
-    public List<CouponHistory> findByUserId(Long userId, int limit, int offset) {
-        // TODO: 사용자별 쿠폰 히스토리 조회 로직 구현
-        return new ArrayList<>();
-    }
-    
+
     @Override
     public CouponHistory save(CouponHistory couponHistory) {
         couponHistories.put(couponHistory.getId(), couponHistory);
         return couponHistory;
     }
-    
+
     @Override
-    public boolean existsByUserIdAndCouponId(Long userId, Long couponId) {
-        // TODO: 사용자-쿠폰 조합 존재 여부 확인 로직 구현
-        return false;
+    public List<CouponHistory> findByUserWithPagination(kr.hhplus.be.server.domain.entity.User user, int limit, int offset) {
+        return couponHistories.values().stream()
+                .filter(history -> history.getUser().equals(user))
+                .skip(offset)
+                .limit(limit)
+                .toList();
     }
 } 

--- a/src/main/java/kr/hhplus/be/server/adapter/storage/inmemory/InMemoryCouponRepository.java
+++ b/src/main/java/kr/hhplus/be/server/adapter/storage/inmemory/InMemoryCouponRepository.java
@@ -12,32 +12,17 @@ import java.util.concurrent.ConcurrentHashMap;
 
 @Repository
 public class InMemoryCouponRepository implements CouponRepositoryPort {
-    
+
     private final Map<Long, Coupon> coupons = new ConcurrentHashMap<>();
-    
+
     @Override
     public Optional<Coupon> findById(Long id) {
         return Optional.ofNullable(coupons.get(id));
     }
-    
+
     @Override
     public Coupon save(Coupon coupon) {
         coupons.put(coupon.getId(), coupon);
         return coupon;
-    }
-    
-    @Override
-    public Coupon updateIssuedCount(Long couponId, int issuedCount) {
-        Coupon coupon = coupons.get(couponId);
-        if (coupon != null) {
-            // TODO: 실제 업데이트 로직 구현
-        }
-        return coupon;
-    }
-    
-    @Override
-    public List<Coupon> findApplicableProducts(Long couponId) {
-        // TODO: 적용 가능한 상품 조회 로직 구현
-        return new ArrayList<>();
     }
 } 

--- a/src/main/java/kr/hhplus/be/server/adapter/storage/inmemory/InMemoryEventLogRepository.java
+++ b/src/main/java/kr/hhplus/be/server/adapter/storage/inmemory/InMemoryEventLogRepository.java
@@ -1,13 +1,15 @@
 package kr.hhplus.be.server.adapter.storage.inmemory;
 
 import kr.hhplus.be.server.domain.entity.EventLog;
+import kr.hhplus.be.server.domain.enums.EventStatus;
+import kr.hhplus.be.server.domain.enums.EventType;
 import kr.hhplus.be.server.domain.port.storage.EventLogRepositoryPort;
 import org.springframework.stereotype.Repository;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 @Repository
 public class InMemoryEventLogRepository implements EventLogRepositoryPort {
@@ -21,14 +23,16 @@ public class InMemoryEventLogRepository implements EventLogRepositoryPort {
     }
     
     @Override
-    public List<EventLog> findByStatus(String status) {
-        // TODO: 상태별 이벤트 로그 조회 로직 구현
-        return new ArrayList<>();
+    public List<EventLog> findByStatus(EventStatus status) {
+        return eventLogs.values().stream()
+                .filter(eventLog -> eventLog.getStatus() == status)
+                .collect(Collectors.toList());
     }
     
     @Override
-    public List<EventLog> findByEventType(String eventType) {
-        // TODO: 이벤트 타입별 조회 로직 구현
-        return new ArrayList<>();
+    public List<EventLog> findByEventType(EventType eventType) {
+        return eventLogs.values().stream()
+                .filter(eventLog -> eventLog.getEventType() == eventType)
+                .collect(Collectors.toList());
     }
 } 

--- a/src/main/java/kr/hhplus/be/server/adapter/storage/inmemory/InMemoryOrderRepository.java
+++ b/src/main/java/kr/hhplus/be/server/adapter/storage/inmemory/InMemoryOrderRepository.java
@@ -12,32 +12,30 @@ import java.util.concurrent.ConcurrentHashMap;
 
 @Repository
 public class InMemoryOrderRepository implements OrderRepositoryPort {
-    
+
     private final Map<Long, Order> orders = new ConcurrentHashMap<>();
-    
-    @Override
-    public Optional<Order> findById(Long id) {
-        return Optional.ofNullable(orders.get(id));
-    }
-    
-    @Override
-    public List<Order> findByUserId(Long userId) {
-        // TODO: 사용자별 주문 조회 로직 구현
-        return new ArrayList<>();
-    }
-    
+
     @Override
     public Order save(Order order) {
         orders.put(order.getId(), order);
         return order;
     }
-    
+
     @Override
-    public Order updateStatus(Long orderId, String status) {
-        Order order = orders.get(orderId);
-        if (order != null) {
-            // TODO: 실제 상태 업데이트 로직 구현
-        }
-        return order;
+    public List<Order> findByUser(kr.hhplus.be.server.domain.entity.User user) {
+        return orders.values().stream()
+                .filter(order -> order.getUser().equals(user))
+                .toList();
+    }
+
+    @Override
+    public Optional<Order> findByIdAndUser(Long orderId, kr.hhplus.be.server.domain.entity.User user) {
+        return Optional.ofNullable(orders.get(orderId))
+                .filter(order -> order.getUser().equals(user));
+    }
+
+    @Override
+    public Optional<Order> findById(Long orderId) {
+        return Optional.ofNullable(orders.get(orderId));
     }
 } 

--- a/src/main/java/kr/hhplus/be/server/adapter/storage/inmemory/InMemoryPaymentRepository.java
+++ b/src/main/java/kr/hhplus/be/server/adapter/storage/inmemory/InMemoryPaymentRepository.java
@@ -1,14 +1,15 @@
 package kr.hhplus.be.server.adapter.storage.inmemory;
 
 import kr.hhplus.be.server.domain.entity.Payment;
+import kr.hhplus.be.server.domain.enums.PaymentStatus;
 import kr.hhplus.be.server.domain.port.storage.PaymentRepositoryPort;
 import org.springframework.stereotype.Repository;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 @Repository
 public class InMemoryPaymentRepository implements PaymentRepositoryPort {
@@ -22,8 +23,9 @@ public class InMemoryPaymentRepository implements PaymentRepositoryPort {
     
     @Override
     public List<Payment> findByOrderId(Long orderId) {
-        // TODO: 주문별 결제 조회 로직 구현
-        return new ArrayList<>();
+        return payments.values().stream()
+                .filter(payment -> payment.getOrder() != null && payment.getOrder().getId().equals(orderId))
+                .collect(Collectors.toList());
     }
     
     @Override
@@ -33,11 +35,12 @@ public class InMemoryPaymentRepository implements PaymentRepositoryPort {
     }
     
     @Override
-    public Payment updateStatus(Long paymentId, String status) {
+    public Payment updateStatus(Long paymentId, PaymentStatus status) {
         Payment payment = payments.get(paymentId);
         if (payment != null) {
-            // TODO: 실제 상태 업데이트 로직 구현
+            payment.changeStatus(status);
+            payments.put(paymentId, payment);
         }
         return payment;
     }
-} 
+}

--- a/src/main/java/kr/hhplus/be/server/adapter/storage/inmemory/InMemoryProductRepository.java
+++ b/src/main/java/kr/hhplus/be/server/adapter/storage/inmemory/InMemoryProductRepository.java
@@ -12,38 +12,31 @@ import java.util.concurrent.ConcurrentHashMap;
 
 @Repository
 public class InMemoryProductRepository implements ProductRepositoryPort {
-    
+
     private final Map<Long, Product> products = new ConcurrentHashMap<>();
-    
+
     @Override
     public Optional<Product> findById(Long id) {
         return Optional.ofNullable(products.get(id));
     }
-    
-    @Override
-    public List<Product> findAll(int limit, int offset) {
-        // TODO: 페이징 로직 구현
-        return new ArrayList<>(products.values());
-    }
-    
+
     @Override
     public Product save(Product product) {
         products.put(product.getId(), product);
         return product;
     }
-    
-    @Override
-    public Product updateStock(Long productId, int stock, int reservedStock) {
-        Product product = products.get(productId);
-        if (product != null) {
-            // TODO: 실제 업데이트 로직 구현
-        }
-        return product;
-    }
-    
+
     @Override
     public List<Product> findPopularProducts(int period) {
-        // TODO: 인기 상품 조회 로직 구현
-        return new ArrayList<>();
+        // Not supported in in-memory repository
+        return List.of();
+    }
+
+    @Override
+    public List<Product> findAllWithPagination(int limit, int offset) {
+        return products.values().stream()
+                .skip(offset)
+                .limit(limit)
+                .toList();
     }
 } 

--- a/src/main/java/kr/hhplus/be/server/api/controller/BalanceController.java
+++ b/src/main/java/kr/hhplus/be/server/api/controller/BalanceController.java
@@ -2,7 +2,7 @@ package kr.hhplus.be.server.api.controller;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import kr.hhplus.be.server.api.dto.request.BalanceChargeRequest;
+import kr.hhplus.be.server.api.dto.request.BalanceRequest;
 import kr.hhplus.be.server.api.dto.response.BalanceResponse;
 import kr.hhplus.be.server.api.swagger.ApiSuccess;
 import kr.hhplus.be.server.domain.entity.Balance;
@@ -30,7 +30,7 @@ public class BalanceController {
     @ApiSuccess(summary = "잔액 충전")
     @PostMapping("/charge")
     @ResponseStatus(HttpStatus.OK)
-    public BalanceResponse chargeBalance(@Valid @RequestBody BalanceChargeRequest request) {
+    public BalanceResponse chargeBalance(@Valid @RequestBody BalanceRequest request) {
         Balance balance = chargeBalanceUseCase.execute(request.getUserId(), request.getAmount());
         return new BalanceResponse(
                 balance.getUser().getId(),

--- a/src/main/java/kr/hhplus/be/server/api/controller/BalanceController.java
+++ b/src/main/java/kr/hhplus/be/server/api/controller/BalanceController.java
@@ -5,8 +5,11 @@ import jakarta.validation.Valid;
 import kr.hhplus.be.server.api.dto.request.BalanceChargeRequest;
 import kr.hhplus.be.server.api.dto.response.BalanceResponse;
 import kr.hhplus.be.server.api.swagger.ApiSuccess;
+import kr.hhplus.be.server.domain.entity.Balance;
 import kr.hhplus.be.server.domain.usecase.balance.ChargeBalanceUseCase;
 import kr.hhplus.be.server.domain.usecase.balance.GetBalanceUseCase;
+
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -28,16 +31,28 @@ public class BalanceController {
     @PostMapping("/charge")
     @ResponseStatus(HttpStatus.OK)
     public BalanceResponse chargeBalance(@Valid @RequestBody BalanceChargeRequest request) {
-        // TODO: 잔액 충전 로직 구현
-        // Balance balance = chargeBalanceUseCase.execute(request.getUserId(), request.getAmount());
-        return new BalanceResponse(request.getUserId(), request.getAmount(), java.time.LocalDateTime.now());
+        Balance balance = chargeBalanceUseCase.execute(request.getUserId(), request.getAmount());
+        return new BalanceResponse(
+                balance.getUser().getId(),
+                balance.getAmount(),
+                balance.getUpdatedAt()
+        );
     }
 
     @ApiSuccess(summary = "잔액 조회")
     @GetMapping("/{userId}")
     public BalanceResponse getBalance(@PathVariable Long userId) {
-        // TODO: 잔액 조회 로직 구현
-        // Optional<Balance> balance = getBalanceUseCase.execute(userId);
-        return new BalanceResponse(userId, new java.math.BigDecimal("50000"), java.time.LocalDateTime.now());
+        Optional<Balance> balanceOpt = getBalanceUseCase.execute(userId);
+        
+        if (balanceOpt.isEmpty()) {
+            throw new kr.hhplus.be.server.domain.exception.BalanceException.InvalidUser();
+        }
+        
+        Balance balance = balanceOpt.get();
+        return new BalanceResponse(
+                balance.getUser().getId(),
+                balance.getAmount(),
+                balance.getUpdatedAt()
+        );
     }
 } 

--- a/src/main/java/kr/hhplus/be/server/api/controller/CouponController.java
+++ b/src/main/java/kr/hhplus/be/server/api/controller/CouponController.java
@@ -1,6 +1,8 @@
 package kr.hhplus.be.server.api.controller;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import kr.hhplus.be.server.api.dto.request.CouponRequest;
 import kr.hhplus.be.server.api.dto.response.CouponResponse;
 import kr.hhplus.be.server.api.swagger.ApiSuccess;
 import kr.hhplus.be.server.domain.entity.CouponHistory;
@@ -28,10 +30,8 @@ public class CouponController {
 
     @ApiSuccess(summary = "쿠폰 발급")
     @PostMapping("/acquire")
-    public CouponResponse acquireCoupon(
-            @RequestParam Long userId,
-            @RequestParam Long couponId) {
-        CouponHistory couponHistory = acquireCouponUseCase.execute(userId, couponId);
+    public CouponResponse acquireCoupon(@Valid @RequestBody CouponRequest request) {
+        CouponHistory couponHistory = acquireCouponUseCase.execute(request.getUserId(), request.getCouponId());
         return new CouponResponse(
                 couponHistory.getCoupon().getId(),
                 couponHistory.getCoupon().getCode(),
@@ -44,9 +44,8 @@ public class CouponController {
     @GetMapping("/{userId}")
     public List<CouponResponse> getCoupons(
             @PathVariable Long userId,
-            @RequestParam(defaultValue = "10") int limit,
-            @RequestParam(defaultValue = "0") int offset) {
-        List<CouponHistory> couponHistories = getCouponListUseCase.execute(userId, limit, offset);
+            @Valid CouponRequest request) {
+        List<CouponHistory> couponHistories = getCouponListUseCase.execute(userId, request.getLimit(), request.getOffset());
         return couponHistories.stream()
                 .map(history -> new CouponResponse(
                         history.getCoupon().getId(),

--- a/src/main/java/kr/hhplus/be/server/api/controller/CouponController.java
+++ b/src/main/java/kr/hhplus/be/server/api/controller/CouponController.java
@@ -3,8 +3,11 @@ package kr.hhplus.be.server.api.controller;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.hhplus.be.server.api.dto.response.CouponResponse;
 import kr.hhplus.be.server.api.swagger.ApiSuccess;
+import kr.hhplus.be.server.domain.entity.CouponHistory;
 import kr.hhplus.be.server.domain.usecase.coupon.AcquireCouponUseCase;
 import kr.hhplus.be.server.domain.usecase.coupon.GetCouponListUseCase;
+
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -28,9 +31,13 @@ public class CouponController {
     public CouponResponse acquireCoupon(
             @RequestParam Long userId,
             @RequestParam Long couponId) {
-        // TODO: 쿠폰 발급 로직 구현
-        // CouponHistory couponHistory = acquireCouponUseCase.execute(userId, couponId);
-        return new CouponResponse(couponId, "COUPON123", new java.math.BigDecimal("0.1"), java.time.LocalDateTime.now().plusDays(30));
+        CouponHistory couponHistory = acquireCouponUseCase.execute(userId, couponId);
+        return new CouponResponse(
+                couponHistory.getCoupon().getId(),
+                couponHistory.getCoupon().getCode(),
+                couponHistory.getCoupon().getDiscountRate(),
+                couponHistory.getCoupon().getEndDate()
+        );
     }
 
     @ApiSuccess(summary = "보유 쿠폰 조회")
@@ -39,11 +46,14 @@ public class CouponController {
             @PathVariable Long userId,
             @RequestParam(defaultValue = "10") int limit,
             @RequestParam(defaultValue = "0") int offset) {
-        // TODO: 보유 쿠폰 조회 로직 구현
-        // List<CouponHistory> couponHistories = getCouponListUseCase.execute(userId, limit, offset);
-        return List.of(
-                new CouponResponse(1L, "COUPON123", new java.math.BigDecimal("0.1"), java.time.LocalDateTime.now().plusDays(30)),
-                new CouponResponse(2L, "COUPON456", new java.math.BigDecimal("0.2"), java.time.LocalDateTime.now().plusDays(60))
-        );
+        List<CouponHistory> couponHistories = getCouponListUseCase.execute(userId, limit, offset);
+        return couponHistories.stream()
+                .map(history -> new CouponResponse(
+                        history.getCoupon().getId(),
+                        history.getCoupon().getCode(),
+                        history.getCoupon().getDiscountRate(),
+                        history.getCoupon().getEndDate()
+                ))
+                .collect(Collectors.toList());
     }
 } 

--- a/src/main/java/kr/hhplus/be/server/api/controller/OrderController.java
+++ b/src/main/java/kr/hhplus/be/server/api/controller/OrderController.java
@@ -2,7 +2,7 @@ package kr.hhplus.be.server.api.controller;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import kr.hhplus.be.server.api.dto.request.CreateOrderRequest;
+import kr.hhplus.be.server.api.dto.request.OrderRequest;
 import kr.hhplus.be.server.api.dto.response.OrderResponse;
 import kr.hhplus.be.server.api.dto.response.PaymentResponse;
 import kr.hhplus.be.server.api.swagger.ApiCreate;
@@ -11,6 +11,7 @@ import kr.hhplus.be.server.domain.entity.Order;
 import kr.hhplus.be.server.domain.entity.Payment;
 import kr.hhplus.be.server.domain.usecase.order.CreateOrderUseCase;
 import kr.hhplus.be.server.domain.usecase.order.PayOrderUseCase;
+import org.springframework.validation.annotation.Validated;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -37,7 +38,7 @@ public class OrderController {
     @ApiCreate(summary = "주문 생성")
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public OrderResponse createOrder(@Valid @RequestBody CreateOrderRequest request) {
+    public OrderResponse createOrder(@Valid @RequestBody OrderRequest request) {
         // productIds를 Map<Long, Integer> 형태로 변환 (각 상품의 수량을 1로 설정)
         Map<Long, Integer> productQuantities = request.getProductIds().stream()
                 .collect(Collectors.toMap(
@@ -71,9 +72,8 @@ public class OrderController {
     @PostMapping("/{orderId}/pay")
     public PaymentResponse payOrder(
             @PathVariable Long orderId,
-            @RequestParam(required = false) Long userId,
-            @RequestParam(required = false) Long couponId) {
-        Payment payment = payOrderUseCase.execute(orderId, userId, couponId);
+            @Valid @RequestBody OrderRequest request) {
+        Payment payment = payOrderUseCase.execute(orderId, request.getUserId(), request.getCouponId());
         
         return new PaymentResponse(
                 payment.getId(),

--- a/src/main/java/kr/hhplus/be/server/api/controller/OrderController.java
+++ b/src/main/java/kr/hhplus/be/server/api/controller/OrderController.java
@@ -9,8 +9,7 @@ import kr.hhplus.be.server.api.swagger.ApiCreate;
 import kr.hhplus.be.server.api.swagger.ApiSuccess;
 import kr.hhplus.be.server.domain.entity.Order;
 import kr.hhplus.be.server.domain.entity.Payment;
-import kr.hhplus.be.server.domain.usecase.order.CreateOrderUseCase;
-import kr.hhplus.be.server.domain.usecase.order.PayOrderUseCase;
+import kr.hhplus.be.server.domain.usecase.order.*;
 import org.springframework.validation.annotation.Validated;
 
 import java.util.HashMap;

--- a/src/main/java/kr/hhplus/be/server/api/controller/ProductController.java
+++ b/src/main/java/kr/hhplus/be/server/api/controller/ProductController.java
@@ -3,8 +3,11 @@ package kr.hhplus.be.server.api.controller;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.hhplus.be.server.api.dto.response.ProductResponse;
 import kr.hhplus.be.server.api.swagger.ApiSuccess;
+import kr.hhplus.be.server.domain.entity.Product;
 import kr.hhplus.be.server.domain.usecase.product.GetProductListUseCase;
 import kr.hhplus.be.server.domain.usecase.product.GetPopularProductListUseCase;
+
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -28,26 +31,30 @@ public class ProductController {
     public List<ProductResponse> getProducts(
             @RequestParam(defaultValue = "10") int limit,
             @RequestParam(defaultValue = "0") int offset) {
-        // TODO: 상품 목록 조회 로직 구현
-        // List<Product> products = getProductListUseCase.execute(limit, offset);
-        return List.of(
-                new ProductResponse(1L, "노트북", new java.math.BigDecimal("1200000"), 50),
-                new ProductResponse(2L, "스마트폰", new java.math.BigDecimal("800000"), 100),
-                new ProductResponse(3L, "태블릿", new java.math.BigDecimal("600000"), 30)
-        );
+        List<Product> products = getProductListUseCase.execute(limit, offset);
+        return products.stream()
+                .map(product -> new ProductResponse(
+                        product.getId(),
+                        product.getName(),
+                        product.getPrice(),
+                        product.getStock()
+                ))
+                .collect(Collectors.toList());
     }
 
     @ApiSuccess(summary = "인기 상품 조회")
     @GetMapping("/popular")
-    public List<ProductResponse> getPopularProducts() {
-        // TODO: 인기 상품 조회 로직 구현 (최근 3일간 상위 5개)
-        // List<Product> popularProducts = getPopularProductListUseCase.execute(3);
-        return List.of(
-                new ProductResponse(2L, "스마트폰", new java.math.BigDecimal("800000"), 100),
-                new ProductResponse(1L, "노트북", new java.math.BigDecimal("1200000"), 50),
-                new ProductResponse(4L, "무선이어폰", new java.math.BigDecimal("200000"), 200),
-                new ProductResponse(5L, "스마트워치", new java.math.BigDecimal("300000"), 80),
-                new ProductResponse(3L, "태블릿", new java.math.BigDecimal("600000"), 30)
-        );
+    public List<ProductResponse> getPopularProducts(
+            @RequestParam(defaultValue = "3") int days) {
+        // 최근 N일간 인기 상품 조회
+        List<Product> popularProducts = getPopularProductListUseCase.execute(days);
+        return popularProducts.stream()
+                .map(product -> new ProductResponse(
+                        product.getId(),
+                        product.getName(),
+                        product.getPrice(),
+                        product.getStock()
+                ))
+                .collect(Collectors.toList());
     }
 } 

--- a/src/main/java/kr/hhplus/be/server/api/controller/ProductController.java
+++ b/src/main/java/kr/hhplus/be/server/api/controller/ProductController.java
@@ -31,7 +31,7 @@ public class ProductController {
 
     @ApiSuccess(summary = "상품 목록 조회")
     @GetMapping("/list")
-    public List<ProductResponse> getProducts(@Valid ProductRequest request) {
+    public List<ProductResponse> getProductList(@Valid ProductRequest request) {
         List<Product> products = getProductListUseCase.execute(request.getLimit(), request.getOffset());
         return products.stream()
                 .map(product -> new ProductResponse(

--- a/src/main/java/kr/hhplus/be/server/api/controller/ProductController.java
+++ b/src/main/java/kr/hhplus/be/server/api/controller/ProductController.java
@@ -1,11 +1,14 @@
 package kr.hhplus.be.server.api.controller;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import kr.hhplus.be.server.api.dto.request.ProductRequest;
 import kr.hhplus.be.server.api.dto.response.ProductResponse;
 import kr.hhplus.be.server.api.swagger.ApiSuccess;
 import kr.hhplus.be.server.domain.entity.Product;
 import kr.hhplus.be.server.domain.usecase.product.GetProductListUseCase;
 import kr.hhplus.be.server.domain.usecase.product.GetPopularProductListUseCase;
+import org.springframework.validation.annotation.Validated;
 
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -28,10 +31,8 @@ public class ProductController {
 
     @ApiSuccess(summary = "상품 목록 조회")
     @GetMapping("/list")
-    public List<ProductResponse> getProducts(
-            @RequestParam(defaultValue = "10") int limit,
-            @RequestParam(defaultValue = "0") int offset) {
-        List<Product> products = getProductListUseCase.execute(limit, offset);
+    public List<ProductResponse> getProducts(@Valid ProductRequest request) {
+        List<Product> products = getProductListUseCase.execute(request.getLimit(), request.getOffset());
         return products.stream()
                 .map(product -> new ProductResponse(
                         product.getId(),
@@ -44,10 +45,9 @@ public class ProductController {
 
     @ApiSuccess(summary = "인기 상품 조회")
     @GetMapping("/popular")
-    public List<ProductResponse> getPopularProducts(
-            @RequestParam(defaultValue = "3") int days) {
+    public List<ProductResponse> getPopularProducts(@Valid ProductRequest request) {
         // 최근 N일간 인기 상품 조회
-        List<Product> popularProducts = getPopularProductListUseCase.execute(days);
+        List<Product> popularProducts = getPopularProductListUseCase.execute(request.getDays());
         return popularProducts.stream()
                 .map(product -> new ProductResponse(
                         product.getId(),

--- a/src/main/java/kr/hhplus/be/server/api/dto/request/BalanceRequest.java
+++ b/src/main/java/kr/hhplus/be/server/api/dto/request/BalanceRequest.java
@@ -3,14 +3,16 @@ package kr.hhplus.be.server.api.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 
 import java.math.BigDecimal;
 
-@Schema(description = "잔액 충전 요청")
-public class BalanceChargeRequest {
+@Schema(description = "잔액 관련 요청")
+public class BalanceRequest {
     
     @Schema(description = "사용자 ID", example = "1", required = true)
     @NotNull(message = "사용자 ID는 필수입니다")
+    @Positive(message = "사용자 ID는 양수여야 합니다")
     private Long userId;
     
     @Schema(description = "충전 금액", example = "10000", required = true)
@@ -19,10 +21,10 @@ public class BalanceChargeRequest {
     private BigDecimal amount;
 
     // 기본 생성자
-    public BalanceChargeRequest() {}
+    public BalanceRequest() {}
 
     // 생성자
-    public BalanceChargeRequest(Long userId, BigDecimal amount) {
+    public BalanceRequest(Long userId, BigDecimal amount) {
         this.userId = userId;
         this.amount = amount;
     }
@@ -32,4 +34,4 @@ public class BalanceChargeRequest {
     public void setUserId(Long userId) { this.userId = userId; }
     public BigDecimal getAmount() { return amount; }
     public void setAmount(BigDecimal amount) { this.amount = amount; }
-} 
+}

--- a/src/main/java/kr/hhplus/be/server/api/dto/request/CouponRequest.java
+++ b/src/main/java/kr/hhplus/be/server/api/dto/request/CouponRequest.java
@@ -1,0 +1,53 @@
+package kr.hhplus.be.server.api.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+
+@Schema(description = "쿠폰 관련 요청")
+public class CouponRequest {
+    
+    @Schema(description = "사용자 ID", example = "1")
+    @NotNull(message = "사용자 ID는 필수입니다")
+    @Positive(message = "사용자 ID는 양수여야 합니다")
+    private Long userId;
+    
+    @Schema(description = "쿠폰 ID", example = "1")
+    @Positive(message = "쿠폰 ID는 양수여야 합니다")
+    private Long couponId;
+    
+    @Schema(description = "페이지 크기", example = "10", defaultValue = "10")
+    @Positive(message = "limit은 양수여야 합니다")
+    @Max(value = 100, message = "limit은 100 이하여야 합니다")
+    private int limit = 10;
+    
+    @Schema(description = "페이지 오프셋", example = "0", defaultValue = "0")
+    @PositiveOrZero(message = "offset은 0 이상이어야 합니다")
+    private int offset = 0;
+
+    // 기본 생성자
+    public CouponRequest() {}
+
+    // 생성자들
+    public CouponRequest(Long userId, Long couponId) {
+        this.userId = userId;
+        this.couponId = couponId;
+    }
+    
+    public CouponRequest(int limit, int offset) {
+        this.limit = limit;
+        this.offset = offset;
+    }
+
+    // Getters and Setters
+    public Long getUserId() { return userId; }
+    public void setUserId(Long userId) { this.userId = userId; }
+    public Long getCouponId() { return couponId; }
+    public void setCouponId(Long couponId) { this.couponId = couponId; }
+    public int getLimit() { return limit; }
+    public void setLimit(int limit) { this.limit = limit; }
+    public int getOffset() { return offset; }
+    public void setOffset(int offset) { this.offset = offset; }
+}

--- a/src/main/java/kr/hhplus/be/server/api/dto/request/OrderRequest.java
+++ b/src/main/java/kr/hhplus/be/server/api/dto/request/OrderRequest.java
@@ -3,31 +3,43 @@ package kr.hhplus.be.server.api.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 
 import java.util.List;
 
-@Schema(description = "주문 생성 요청")
-public class CreateOrderRequest {
+@Schema(description = "주문 관련 요청")
+public class OrderRequest {
     
-    @Schema(description = "사용자 ID", example = "1", required = true)
+    @Schema(description = "사용자 ID", example = "1")
     @NotNull(message = "사용자 ID는 필수입니다")
+    @Positive(message = "사용자 ID는 양수여야 합니다")
     private Long userId;
     
-    @Schema(description = "상품 ID 목록", example = "[1, 2, 3]", required = true)
+    @Schema(description = "상품 ID 목록", example = "[1, 2, 3]")
     @NotEmpty(message = "상품 목록은 필수입니다")
     private List<Long> productIds;
     
     @Schema(description = "쿠폰 ID 목록", example = "[1, 2]")
     private List<Long> couponIds;
+    
+    @Schema(description = "쿠폰 ID (결제 시 사용)", example = "1")
+    @Positive(message = "쿠폰 ID는 양수여야 합니다")
+    private Long couponId;
 
     // 기본 생성자
-    public CreateOrderRequest() {}
+    public OrderRequest() {}
 
-    // 생성자
-    public CreateOrderRequest(Long userId, List<Long> productIds, List<Long> couponIds) {
+    // 주문 생성용 생성자
+    public OrderRequest(Long userId, List<Long> productIds, List<Long> couponIds) {
         this.userId = userId;
         this.productIds = productIds;
         this.couponIds = couponIds;
+    }
+    
+    // 결제용 생성자
+    public OrderRequest(Long userId, Long couponId) {
+        this.userId = userId;
+        this.couponId = couponId;
     }
 
     // Getters and Setters
@@ -37,4 +49,6 @@ public class CreateOrderRequest {
     public void setProductIds(List<Long> productIds) { this.productIds = productIds; }
     public List<Long> getCouponIds() { return couponIds; }
     public void setCouponIds(List<Long> couponIds) { this.couponIds = couponIds; }
-} 
+    public Long getCouponId() { return couponId; }
+    public void setCouponId(Long couponId) { this.couponId = couponId; }
+}

--- a/src/main/java/kr/hhplus/be/server/api/dto/request/ProductRequest.java
+++ b/src/main/java/kr/hhplus/be/server/api/dto/request/ProductRequest.java
@@ -1,0 +1,45 @@
+package kr.hhplus.be.server.api.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+
+@Schema(description = "상품 관련 요청")
+public class ProductRequest {
+    
+    @Schema(description = "페이지 크기", example = "10", defaultValue = "10")
+    @Positive(message = "limit은 양수여야 합니다")
+    @Max(value = 100, message = "limit은 100 이하여야 합니다")
+    private int limit = 10;
+    
+    @Schema(description = "페이지 오프셋", example = "0", defaultValue = "0")
+    @PositiveOrZero(message = "offset은 0 이상이어야 합니다")
+    private int offset = 0;
+    
+    @Schema(description = "조회 기간(일)", example = "3", defaultValue = "3")
+    @Positive(message = "조회 기간(일)은 양수여야 합니다")
+    @Max(value = 30, message = "조회 기간은 30일 이하여야 합니다")
+    private int days = 3;
+
+    // 기본 생성자
+    public ProductRequest() {}
+
+    // 생성자들
+    public ProductRequest(int limit, int offset) {
+        this.limit = limit;
+        this.offset = offset;
+    }
+    
+    public ProductRequest(int days) {
+        this.days = days;
+    }
+
+    // Getters and Setters
+    public int getLimit() { return limit; }
+    public void setLimit(int limit) { this.limit = limit; }
+    public int getOffset() { return offset; }
+    public void setOffset(int offset) { this.offset = offset; }
+    public int getDays() { return days; }
+    public void setDays(int days) { this.days = days; }
+}

--- a/src/main/java/kr/hhplus/be/server/domain/entity/Balance.java
+++ b/src/main/java/kr/hhplus/be/server/domain/entity/Balance.java
@@ -2,13 +2,14 @@ package kr.hhplus.be.server.domain.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 import java.math.BigDecimal;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Builder
+@SuperBuilder
 @Entity
 public class Balance extends BaseEntity {
 
@@ -18,4 +19,15 @@ public class Balance extends BaseEntity {
 
     @Column(nullable = false, precision = 19, scale = 2)
     private BigDecimal amount;
+
+    public void addAmount(BigDecimal amount) {
+        this.amount = this.amount.add(amount);
+    }
+
+    public void subtractAmount(BigDecimal amount) {
+        if (this.amount.compareTo(amount) < 0) {
+            throw new RuntimeException("Insufficient balance");
+        }
+        this.amount = this.amount.subtract(amount);
+    }
 } 

--- a/src/main/java/kr/hhplus/be/server/domain/entity/BaseEntity.java
+++ b/src/main/java/kr/hhplus/be/server/domain/entity/BaseEntity.java
@@ -2,7 +2,9 @@ package kr.hhplus.be.server.domain.entity;
 
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.experimental.SuperBuilder;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -11,6 +13,8 @@ import java.time.LocalDateTime;
 
 @Getter
 @Setter
+@NoArgsConstructor
+@SuperBuilder
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {

--- a/src/main/java/kr/hhplus/be/server/domain/entity/Coupon.java
+++ b/src/main/java/kr/hhplus/be/server/domain/entity/Coupon.java
@@ -2,6 +2,7 @@ package kr.hhplus.be.server.domain.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -9,7 +10,7 @@ import java.time.LocalDateTime;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Builder
+@SuperBuilder
 @Entity
 public class Coupon extends BaseEntity {
 
@@ -29,4 +30,11 @@ public class Coupon extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "product_id")
     private Product product;
+
+    public void decreaseStock(int quantity) {
+        if (this.issuedCount + quantity > this.maxIssuance) {
+            throw new RuntimeException("Coupon stock exceeded");
+        }
+        this.issuedCount += quantity;
+    }
 } 

--- a/src/main/java/kr/hhplus/be/server/domain/entity/CouponHistory.java
+++ b/src/main/java/kr/hhplus/be/server/domain/entity/CouponHistory.java
@@ -2,13 +2,14 @@ package kr.hhplus.be.server.domain.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Builder
+@SuperBuilder
 @Entity
 public class CouponHistory extends BaseEntity {
 

--- a/src/main/java/kr/hhplus/be/server/domain/entity/EventLog.java
+++ b/src/main/java/kr/hhplus/be/server/domain/entity/EventLog.java
@@ -4,11 +4,12 @@ import jakarta.persistence.*;
 import kr.hhplus.be.server.domain.enums.EventStatus;
 import kr.hhplus.be.server.domain.enums.EventType;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Builder
+@SuperBuilder
 @Entity
 public class EventLog extends BaseEntity {
 

--- a/src/main/java/kr/hhplus/be/server/domain/entity/Order.java
+++ b/src/main/java/kr/hhplus/be/server/domain/entity/Order.java
@@ -2,6 +2,7 @@ package kr.hhplus.be.server.domain.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -10,7 +11,7 @@ import java.util.List;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Builder
+@SuperBuilder
 @Entity
 @Table(name = "orders")
 public class Order extends BaseEntity {
@@ -22,9 +23,11 @@ public class Order extends BaseEntity {
     @Column(nullable = false, precision = 19, scale = 2)
     private BigDecimal totalAmount;
 
+    @Builder.Default
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<OrderItem> items = new ArrayList<>();
 
+    @Builder.Default
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Payment> payments = new ArrayList<>();
 } 

--- a/src/main/java/kr/hhplus/be/server/domain/entity/OrderItem.java
+++ b/src/main/java/kr/hhplus/be/server/domain/entity/OrderItem.java
@@ -2,13 +2,14 @@ package kr.hhplus.be.server.domain.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 import java.math.BigDecimal;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Builder
+@SuperBuilder
 @Entity
 public class OrderItem extends BaseEntity {
 

--- a/src/main/java/kr/hhplus/be/server/domain/entity/Payment.java
+++ b/src/main/java/kr/hhplus/be/server/domain/entity/Payment.java
@@ -2,6 +2,7 @@ package kr.hhplus.be.server.domain.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import kr.hhplus.be.server.domain.enums.PaymentStatus;
 
 import java.math.BigDecimal;
@@ -9,7 +10,7 @@ import java.math.BigDecimal;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Builder
+@SuperBuilder
 @Entity
 public class Payment extends BaseEntity {
 
@@ -30,4 +31,8 @@ public class Payment extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "coupon_id")
     private Coupon coupon;
+
+    public void changeStatus(PaymentStatus status) {
+        this.status = status;
+    }
 } 

--- a/src/main/java/kr/hhplus/be/server/domain/entity/Product.java
+++ b/src/main/java/kr/hhplus/be/server/domain/entity/Product.java
@@ -2,13 +2,14 @@ package kr.hhplus.be.server.domain.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 import java.math.BigDecimal;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Builder
+@SuperBuilder
 @Entity
 public class Product extends BaseEntity {
 
@@ -20,4 +21,11 @@ public class Product extends BaseEntity {
     private int stock;
 
     private int reservedStock;
+
+    public void decreaseStock(int quantity) {
+        if (this.stock - quantity < 0) {
+            throw new RuntimeException("Product stock exceeded");
+        }
+        this.stock -= quantity;
+    }
 } 

--- a/src/main/java/kr/hhplus/be/server/domain/entity/User.java
+++ b/src/main/java/kr/hhplus/be/server/domain/entity/User.java
@@ -2,6 +2,7 @@ package kr.hhplus.be.server.domain.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -9,7 +10,7 @@ import java.util.List;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Builder
+@SuperBuilder
 @Entity
 @Table(name = "users")
 public class User extends BaseEntity {
@@ -19,9 +20,11 @@ public class User extends BaseEntity {
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private Balance balance;
 
+    @Builder.Default
     @OneToMany(mappedBy = "user")
     private List<Order> orders = new ArrayList<>();
 
+    @Builder.Default
     @OneToMany(mappedBy = "user")
     private List<CouponHistory> couponHistories = new ArrayList<>();
 } 

--- a/src/main/java/kr/hhplus/be/server/domain/port/cache/CachePort.java
+++ b/src/main/java/kr/hhplus/be/server/domain/port/cache/CachePort.java
@@ -2,9 +2,10 @@ package kr.hhplus.be.server.domain.port.cache;
 
 import java.util.Optional;
 
+import java.util.function.Supplier;
+
 public interface CachePort {
-    <T> Optional<T> get(String key, Class<T> type);
-    void set(String key, Object value);
-    void delete(String key);
-    boolean exists(String key);
+    <T> T get(String key, Class<T> type, Supplier<T> supplier);
+    void put(String key, Object value, int ttlSeconds);
+    void evict(String key);
 } 

--- a/src/main/java/kr/hhplus/be/server/domain/port/storage/BalanceRepositoryPort.java
+++ b/src/main/java/kr/hhplus/be/server/domain/port/storage/BalanceRepositoryPort.java
@@ -5,7 +5,6 @@ import kr.hhplus.be.server.domain.entity.Balance;
 import java.util.Optional;
 
 public interface BalanceRepositoryPort {
-    Optional<Balance> findByUserId(Long userId);
+    Optional<Balance> findByUser(kr.hhplus.be.server.domain.entity.User user);
     Balance save(Balance balance);
-    Balance updateAmount(Long userId, java.math.BigDecimal amount);
 } 

--- a/src/main/java/kr/hhplus/be/server/domain/port/storage/CouponHistoryRepositoryPort.java
+++ b/src/main/java/kr/hhplus/be/server/domain/port/storage/CouponHistoryRepositoryPort.java
@@ -6,8 +6,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface CouponHistoryRepositoryPort {
-    Optional<CouponHistory> findById(Long id);
-    List<CouponHistory> findByUserId(Long userId, int limit, int offset);
+    boolean existsByUserAndCoupon(kr.hhplus.be.server.domain.entity.User user, kr.hhplus.be.server.domain.entity.Coupon coupon);
     CouponHistory save(CouponHistory couponHistory);
-    boolean existsByUserIdAndCouponId(Long userId, Long couponId);
+    List<CouponHistory> findByUserWithPagination(kr.hhplus.be.server.domain.entity.User user, int limit, int offset);
 } 

--- a/src/main/java/kr/hhplus/be/server/domain/port/storage/CouponRepositoryPort.java
+++ b/src/main/java/kr/hhplus/be/server/domain/port/storage/CouponRepositoryPort.java
@@ -8,6 +8,4 @@ import java.util.Optional;
 public interface CouponRepositoryPort {
     Optional<Coupon> findById(Long id);
     Coupon save(Coupon coupon);
-    Coupon updateIssuedCount(Long couponId, int issuedCount);
-    List<Coupon> findApplicableProducts(Long couponId);
 } 

--- a/src/main/java/kr/hhplus/be/server/domain/port/storage/EventLogRepositoryPort.java
+++ b/src/main/java/kr/hhplus/be/server/domain/port/storage/EventLogRepositoryPort.java
@@ -1,11 +1,13 @@
 package kr.hhplus.be.server.domain.port.storage;
 
 import kr.hhplus.be.server.domain.entity.EventLog;
+import kr.hhplus.be.server.domain.enums.EventStatus;
+import kr.hhplus.be.server.domain.enums.EventType;
 
 import java.util.List;
 
 public interface EventLogRepositoryPort {
     EventLog save(EventLog eventLog);
-    List<EventLog> findByStatus(String status);
-    List<EventLog> findByEventType(String eventType);
+    List<EventLog> findByStatus(EventStatus status);
+    List<EventLog> findByEventType(EventType eventType);
 } 

--- a/src/main/java/kr/hhplus/be/server/domain/port/storage/OrderRepositoryPort.java
+++ b/src/main/java/kr/hhplus/be/server/domain/port/storage/OrderRepositoryPort.java
@@ -6,8 +6,8 @@ import java.util.List;
 import java.util.Optional;
 
 public interface OrderRepositoryPort {
-    Optional<Order> findById(Long id);
-    List<Order> findByUserId(Long userId);
     Order save(Order order);
-    Order updateStatus(Long orderId, String status);
+    List<Order> findByUser(kr.hhplus.be.server.domain.entity.User user);
+    Optional<Order> findByIdAndUser(Long orderId, kr.hhplus.be.server.domain.entity.User user);
+    Optional<Order> findById(Long orderId);
 } 

--- a/src/main/java/kr/hhplus/be/server/domain/port/storage/PaymentRepositoryPort.java
+++ b/src/main/java/kr/hhplus/be/server/domain/port/storage/PaymentRepositoryPort.java
@@ -1,6 +1,7 @@
 package kr.hhplus.be.server.domain.port.storage;
 
 import kr.hhplus.be.server.domain.entity.Payment;
+import kr.hhplus.be.server.domain.enums.PaymentStatus;
 
 import java.util.List;
 import java.util.Optional;
@@ -9,5 +10,5 @@ public interface PaymentRepositoryPort {
     Optional<Payment> findById(Long id);
     List<Payment> findByOrderId(Long orderId);
     Payment save(Payment payment);
-    Payment updateStatus(Long paymentId, String status);
+    Payment updateStatus(Long paymentId, PaymentStatus status);
 } 

--- a/src/main/java/kr/hhplus/be/server/domain/port/storage/ProductRepositoryPort.java
+++ b/src/main/java/kr/hhplus/be/server/domain/port/storage/ProductRepositoryPort.java
@@ -7,8 +7,7 @@ import java.util.Optional;
 
 public interface ProductRepositoryPort {
     Optional<Product> findById(Long id);
-    List<Product> findAll(int limit, int offset);
     Product save(Product product);
-    Product updateStock(Long productId, int stock, int reservedStock);
     List<Product> findPopularProducts(int period);
+    List<Product> findAllWithPagination(int limit, int offset);
 } 

--- a/src/main/java/kr/hhplus/be/server/domain/usecase/balance/ChargeBalanceUseCase.java
+++ b/src/main/java/kr/hhplus/be/server/domain/usecase/balance/ChargeBalanceUseCase.java
@@ -1,6 +1,7 @@
 package kr.hhplus.be.server.domain.usecase.balance;
 
 import kr.hhplus.be.server.domain.entity.Balance;
+import kr.hhplus.be.server.domain.entity.User;
 import kr.hhplus.be.server.domain.port.storage.UserRepositoryPort;
 import kr.hhplus.be.server.domain.port.storage.BalanceRepositoryPort;
 import kr.hhplus.be.server.domain.port.locking.LockingPort;
@@ -20,7 +21,21 @@ public class ChargeBalanceUseCase {
     private final CachePort cachePort;
     
     public Balance execute(Long userId, BigDecimal amount) {
-        // TODO: 잔액 충전 로직 구현
-        return null;
+        String lockKey = "balance-charge-" + userId;
+        if (!lockingPort.acquireLock(lockKey)) {
+            throw new RuntimeException("Failed to acquire lock");
+        }
+        try {
+            User user = userRepositoryPort.findById(userId)
+                    .orElseThrow(() -> new RuntimeException("User not found"));
+            Balance balance = balanceRepositoryPort.findByUser(user)
+                    .orElse(Balance.builder().user(user).amount(BigDecimal.ZERO).build());
+            balance.addAmount(amount);
+            Balance savedBalance = balanceRepositoryPort.save(balance);
+            cachePort.put("balance:" + userId, savedBalance, 600);
+            return savedBalance;
+        } finally {
+            lockingPort.releaseLock(lockKey);
+        }
     }
 } 

--- a/src/main/java/kr/hhplus/be/server/domain/usecase/balance/GetBalanceUseCase.java
+++ b/src/main/java/kr/hhplus/be/server/domain/usecase/balance/GetBalanceUseCase.java
@@ -1,6 +1,7 @@
 package kr.hhplus.be.server.domain.usecase.balance;
 
 import kr.hhplus.be.server.domain.entity.Balance;
+import kr.hhplus.be.server.domain.entity.User;
 import kr.hhplus.be.server.domain.port.storage.UserRepositoryPort;
 import kr.hhplus.be.server.domain.port.storage.BalanceRepositoryPort;
 import kr.hhplus.be.server.domain.port.cache.CachePort;
@@ -18,7 +19,10 @@ public class GetBalanceUseCase {
     private final CachePort cachePort;
     
     public Optional<Balance> execute(Long userId) {
-        // TODO: 잔액 조회 로직 구현
-        return Optional.empty();
+        return Optional.ofNullable(cachePort.get("balance:" + userId, Balance.class, () -> {
+            User user = userRepositoryPort.findById(userId)
+                    .orElseThrow(() -> new RuntimeException("User not found"));
+            return balanceRepositoryPort.findByUser(user).orElse(null);
+        }));
     }
 } 

--- a/src/main/java/kr/hhplus/be/server/domain/usecase/coupon/AcquireCouponUseCase.java
+++ b/src/main/java/kr/hhplus/be/server/domain/usecase/coupon/AcquireCouponUseCase.java
@@ -1,6 +1,8 @@
 package kr.hhplus.be.server.domain.usecase.coupon;
 
+import kr.hhplus.be.server.domain.entity.Coupon;
 import kr.hhplus.be.server.domain.entity.CouponHistory;
+import kr.hhplus.be.server.domain.entity.User;
 import kr.hhplus.be.server.domain.port.storage.UserRepositoryPort;
 import kr.hhplus.be.server.domain.port.storage.CouponRepositoryPort;
 import kr.hhplus.be.server.domain.port.storage.CouponHistoryRepositoryPort;
@@ -18,7 +20,30 @@ public class AcquireCouponUseCase {
     private final LockingPort lockingPort;
     
     public CouponHistory execute(Long userId, Long couponId) {
-        // TODO: 쿠폰 발급 로직 구현
-        return null;
+        String lockKey = "coupon-acquire-" + couponId;
+        if (!lockingPort.acquireLock(lockKey)) {
+            throw new RuntimeException("Failed to acquire lock");
+        }
+        try {
+            User user = userRepositoryPort.findById(userId)
+                    .orElseThrow(() -> new RuntimeException("User not found"));
+            Coupon coupon = couponRepositoryPort.findById(couponId)
+                    .orElseThrow(() -> new RuntimeException("Coupon not found"));
+
+            if (couponHistoryRepositoryPort.existsByUserAndCoupon(user, coupon)) {
+                throw new RuntimeException("Coupon already acquired");
+            }
+
+            coupon.decreaseStock(1);
+            Coupon savedCoupon = couponRepositoryPort.save(coupon);
+
+            CouponHistory couponHistory = CouponHistory.builder()
+                    .user(user)
+                    .coupon(savedCoupon)
+                    .build();
+            return couponHistoryRepositoryPort.save(couponHistory);
+        } finally {
+            lockingPort.releaseLock(lockKey);
+        }
     }
 } 

--- a/src/main/java/kr/hhplus/be/server/domain/usecase/coupon/GetCouponListUseCase.java
+++ b/src/main/java/kr/hhplus/be/server/domain/usecase/coupon/GetCouponListUseCase.java
@@ -1,6 +1,7 @@
 package kr.hhplus.be.server.domain.usecase.coupon;
 
 import kr.hhplus.be.server.domain.entity.CouponHistory;
+import kr.hhplus.be.server.domain.entity.User;
 import kr.hhplus.be.server.domain.port.storage.UserRepositoryPort;
 import kr.hhplus.be.server.domain.port.storage.CouponHistoryRepositoryPort;
 import lombok.RequiredArgsConstructor;
@@ -16,7 +17,8 @@ public class GetCouponListUseCase {
     private final CouponHistoryRepositoryPort couponHistoryRepositoryPort;
     
     public List<CouponHistory> execute(Long userId, int limit, int offset) {
-        // TODO: 보유 쿠폰 목록 조회 로직 구현
-        return List.of();
+        User user = userRepositoryPort.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        return couponHistoryRepositoryPort.findByUserWithPagination(user, limit, offset);
     }
 } 

--- a/src/main/java/kr/hhplus/be/server/domain/usecase/order/CreateOrderUseCase.java
+++ b/src/main/java/kr/hhplus/be/server/domain/usecase/order/CreateOrderUseCase.java
@@ -1,6 +1,9 @@
 package kr.hhplus.be.server.domain.usecase.order;
 
 import kr.hhplus.be.server.domain.entity.Order;
+import kr.hhplus.be.server.domain.entity.OrderItem;
+import kr.hhplus.be.server.domain.entity.Product;
+import kr.hhplus.be.server.domain.entity.User;
 import kr.hhplus.be.server.domain.port.storage.UserRepositoryPort;
 import kr.hhplus.be.server.domain.port.storage.ProductRepositoryPort;
 import kr.hhplus.be.server.domain.port.storage.OrderRepositoryPort;
@@ -10,21 +13,57 @@ import kr.hhplus.be.server.domain.port.cache.CachePort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.math.BigDecimal;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
 public class CreateOrderUseCase {
-    
+
     private final UserRepositoryPort userRepositoryPort;
     private final ProductRepositoryPort productRepositoryPort;
     private final OrderRepositoryPort orderRepositoryPort;
     private final EventLogRepositoryPort eventLogRepositoryPort;
     private final LockingPort lockingPort;
     private final CachePort cachePort;
-    
+
     public Order execute(Long userId, Map<Long, Integer> productQuantities) {
-        // TODO: 주문 생성 로직 구현
-        return null;
+        String lockKey = "order-creation-" + userId;
+        if (!lockingPort.acquireLock(lockKey)) {
+            throw new RuntimeException("Failed to acquire lock");
+        }
+        try {
+            User user = userRepositoryPort.findById(userId)
+                    .orElseThrow(() -> new RuntimeException("User not found"));
+
+            List<OrderItem> orderItems = productQuantities.entrySet().stream()
+                    .map(entry -> {
+                        Product product = productRepositoryPort.findById(entry.getKey())
+                                .orElseThrow(() -> new RuntimeException("Product not found"));
+                        product.decreaseStock(entry.getValue());
+                        productRepositoryPort.save(product);
+                        return OrderItem.builder()
+                                .product(product)
+                                .quantity(entry.getValue())
+                                .price(product.getPrice())
+                                .build();
+                    }).collect(Collectors.toList());
+
+            BigDecimal totalAmount = orderItems.stream()
+                    .map(item -> item.getPrice().multiply(new BigDecimal(item.getQuantity())))
+                    .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+            Order order = Order.builder()
+                    .user(user)
+                    .totalAmount(totalAmount)
+                    .items(orderItems)
+                    .build();
+
+            return orderRepositoryPort.save(order);
+        } finally {
+            lockingPort.releaseLock(lockKey);
+        }
     }
-} 
+}

--- a/src/main/java/kr/hhplus/be/server/domain/usecase/order/GetOrderListUseCase.java
+++ b/src/main/java/kr/hhplus/be/server/domain/usecase/order/GetOrderListUseCase.java
@@ -1,6 +1,7 @@
 package kr.hhplus.be.server.domain.usecase.order;
 
 import kr.hhplus.be.server.domain.entity.Order;
+import kr.hhplus.be.server.domain.entity.User;
 import kr.hhplus.be.server.domain.port.storage.UserRepositoryPort;
 import kr.hhplus.be.server.domain.port.storage.OrderRepositoryPort;
 import lombok.RequiredArgsConstructor;
@@ -16,7 +17,8 @@ public class GetOrderListUseCase {
     private final OrderRepositoryPort orderRepositoryPort;
     
     public List<Order> execute(Long userId) {
-        // TODO: 주문 목록 조회 로직 구현
-        return List.of();
+        User user = userRepositoryPort.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        return orderRepositoryPort.findByUser(user);
     }
 } 

--- a/src/main/java/kr/hhplus/be/server/domain/usecase/order/GetOrderUseCase.java
+++ b/src/main/java/kr/hhplus/be/server/domain/usecase/order/GetOrderUseCase.java
@@ -1,6 +1,7 @@
 package kr.hhplus.be.server.domain.usecase.order;
 
 import kr.hhplus.be.server.domain.entity.Order;
+import kr.hhplus.be.server.domain.entity.User;
 import kr.hhplus.be.server.domain.port.storage.UserRepositoryPort;
 import kr.hhplus.be.server.domain.port.storage.OrderRepositoryPort;
 import lombok.RequiredArgsConstructor;
@@ -16,7 +17,8 @@ public class GetOrderUseCase {
     private final OrderRepositoryPort orderRepositoryPort;
     
     public Optional<Order> execute(Long userId, Long orderId) {
-        // TODO: 단일 주문 조회 로직 구현
-        return Optional.empty();
+        User user = userRepositoryPort.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        return orderRepositoryPort.findByIdAndUser(orderId, user);
     }
 } 

--- a/src/main/java/kr/hhplus/be/server/domain/usecase/order/PayOrderUseCase.java
+++ b/src/main/java/kr/hhplus/be/server/domain/usecase/order/PayOrderUseCase.java
@@ -1,17 +1,15 @@
 package kr.hhplus.be.server.domain.usecase.order;
 
-import kr.hhplus.be.server.domain.entity.Payment;
-import kr.hhplus.be.server.domain.port.storage.UserRepositoryPort;
-import kr.hhplus.be.server.domain.port.storage.BalanceRepositoryPort;
-import kr.hhplus.be.server.domain.port.storage.OrderRepositoryPort;
-import kr.hhplus.be.server.domain.port.storage.PaymentRepositoryPort;
-import kr.hhplus.be.server.domain.port.storage.CouponRepositoryPort;
-import kr.hhplus.be.server.domain.port.storage.EventLogRepositoryPort;
+import kr.hhplus.be.server.domain.entity.*;
+import kr.hhplus.be.server.domain.enums.PaymentStatus;
+import kr.hhplus.be.server.domain.port.storage.*;
 import kr.hhplus.be.server.domain.port.locking.LockingPort;
 import kr.hhplus.be.server.domain.port.cache.CachePort;
 import kr.hhplus.be.server.domain.port.messaging.MessagingPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
 
 @Component
 @RequiredArgsConstructor
@@ -28,7 +26,38 @@ public class PayOrderUseCase {
     private final MessagingPort messagingPort;
     
     public Payment execute(Long orderId, Long userId, Long couponId) {
-        // TODO: 주문 결제 로직 구현
-        return null;
+        String lockKey = "payment-" + orderId;
+        if (!lockingPort.acquireLock(lockKey)) {
+            throw new RuntimeException("Failed to acquire lock");
+        }
+        try {
+            User user = userRepositoryPort.findById(userId)
+                    .orElseThrow(() -> new RuntimeException("User not found"));
+            Order order = orderRepositoryPort.findById(orderId)
+                    .orElseThrow(() -> new RuntimeException("Order not found"));
+
+            BigDecimal finalAmount = order.getTotalAmount();
+            if (couponId != null) {
+                Coupon coupon = couponRepositoryPort.findById(couponId)
+                        .orElseThrow(() -> new RuntimeException("Coupon not found"));
+                finalAmount = finalAmount.multiply(BigDecimal.ONE.subtract(coupon.getDiscountRate()));
+            }
+
+            Balance balance = balanceRepositoryPort.findByUser(user)
+                    .orElseThrow(() -> new RuntimeException("Balance not found"));
+            balance.subtractAmount(finalAmount);
+            balanceRepositoryPort.save(balance);
+
+            Payment payment = Payment.builder()
+                    .order(order)
+                    .user(user)
+                    .amount(finalAmount)
+                    .status(PaymentStatus.PAID)
+                    .build();
+
+            return paymentRepositoryPort.save(payment);
+        } finally {
+            lockingPort.releaseLock(lockKey);
+        }
     }
 } 

--- a/src/main/java/kr/hhplus/be/server/domain/usecase/product/GetPopularProductListUseCase.java
+++ b/src/main/java/kr/hhplus/be/server/domain/usecase/product/GetPopularProductListUseCase.java
@@ -16,7 +16,8 @@ public class GetPopularProductListUseCase {
     private final CachePort cachePort;
     
     public List<Product> execute(int period) {
-        // TODO: 인기 상품 목록 조회 로직 구현
-        return List.of();
+        // 인기 상품 조회 로직은 복잡하므로, 여기서는 단순한 예시를 제공합니다.
+        // 실제로는 주문 데이터를 기반으로 집계해야 합니다.
+        return productRepositoryPort.findPopularProducts(period);
     }
 } 

--- a/src/main/java/kr/hhplus/be/server/domain/usecase/product/GetProductListUseCase.java
+++ b/src/main/java/kr/hhplus/be/server/domain/usecase/product/GetProductListUseCase.java
@@ -16,7 +16,6 @@ public class GetProductListUseCase {
     private final CachePort cachePort;
     
     public List<Product> execute(int limit, int offset) {
-        // TODO: 상품 목록 조회 로직 구현
-        return List.of();
+        return productRepositoryPort.findAllWithPagination(limit, offset);
     }
 } 

--- a/src/main/java/kr/hhplus/be/server/domain/usecase/product/GetProductUseCase.java
+++ b/src/main/java/kr/hhplus/be/server/domain/usecase/product/GetProductUseCase.java
@@ -16,7 +16,6 @@ public class GetProductUseCase {
     private final CachePort cachePort;
     
     public Optional<Product> execute(Long productId) {
-        // TODO: 단일 상품 조회 로직 구현
-        return Optional.empty();
+        return productRepositoryPort.findById(productId);
     }
 } 

--- a/src/test/java/kr/hhplus/be/server/integration/BalanceTest.java
+++ b/src/test/java/kr/hhplus/be/server/integration/BalanceTest.java
@@ -1,7 +1,7 @@
 package kr.hhplus.be.server.integration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import kr.hhplus.be.server.api.dto.request.BalanceChargeRequest;
+import kr.hhplus.be.server.api.dto.request.BalanceRequest;
 import kr.hhplus.be.server.api.controller.BalanceController;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -35,7 +35,7 @@ public class BalanceTest {
         // given
         long userId = 1L;
         BigDecimal amount = new BigDecimal("10000");
-        BalanceChargeRequest request = new BalanceChargeRequest(userId, amount);
+        BalanceRequest request = new BalanceRequest(userId, amount);
 
         // when
         ResultActions resultActions = mockMvc.perform(post("/api/balance/charge")

--- a/src/test/java/kr/hhplus/be/server/integration/OrderTest.java
+++ b/src/test/java/kr/hhplus/be/server/integration/OrderTest.java
@@ -1,7 +1,7 @@
 package kr.hhplus.be.server.integration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import kr.hhplus.be.server.api.dto.request.CreateOrderRequest;
+import kr.hhplus.be.server.api.dto.request.OrderRequest;
 import kr.hhplus.be.server.api.controller.OrderController;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -36,7 +36,7 @@ public class OrderTest {
         long userId = 1L;
         List<Long> productIds = List.of(1L, 2L);
         List<Long> couponIds = List.of(1L);
-        CreateOrderRequest request = new CreateOrderRequest(userId, productIds, couponIds);
+        OrderRequest request = new OrderRequest(userId, productIds, couponIds);
 
         // when
         ResultActions resultActions = mockMvc.perform(post("/api/order")

--- a/src/test/java/kr/hhplus/be/server/unit/adapter/storage/inmemory/InMemoryBalanceRepositoryTest.java
+++ b/src/test/java/kr/hhplus/be/server/unit/adapter/storage/inmemory/InMemoryBalanceRepositoryTest.java
@@ -50,19 +50,21 @@ class InMemoryBalanceRepositoryTest {
 
     @Test
     @DisplayName("사용자 ID로 잔액 조회 성공")
-    void findByUserId_Success() {
+    void findByUser_Success() {
         // given
         User user = User.builder()
+                .id(1L)
                 .name("테스트 사용자")
                 .build();
         Balance balance = Balance.builder()
+                .id(1L)
                 .user(user)
                 .amount(new BigDecimal("50000"))
                 .build();
         balanceRepository.save(balance);
 
         // when
-        Optional<Balance> foundBalance = balanceRepository.findByUserId(user.getId());
+        Optional<Balance> foundBalance = balanceRepository.findByUser(user);
 
         // then
         assertThat(foundBalance).isPresent();
@@ -71,9 +73,12 @@ class InMemoryBalanceRepositoryTest {
 
     @Test
     @DisplayName("존재하지 않는 사용자 잔액 조회")
-    void findByUserId_NotFound() {
+    void findByUser_NotFound() {
+        // given
+        User user = User.builder().id(999L).build();
+
         // when
-        Optional<Balance> foundBalance = balanceRepository.findByUserId(999L);
+        Optional<Balance> foundBalance = balanceRepository.findByUser(user);
 
         // then
         assertThat(foundBalance).isEmpty();
@@ -105,15 +110,18 @@ class InMemoryBalanceRepositoryTest {
     @DisplayName("null 사용자 ID로 조회 시 예외 발생")
     void findByUserId_WithNullUserId() {
         // when & then
-        assertThatThrownBy(() -> balanceRepository.findByUserId(null))
+        assertThatThrownBy(() -> balanceRepository.findByUser(null))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     @DisplayName("음수 사용자 ID로 조회")
     void findByUserId_WithNegativeUserId() {
+        // given
+        User user = User.builder().id(-1L).name("테스트 사용자").build();
+        
         // when
-        Optional<Balance> foundBalance = balanceRepository.findByUserId(-1L);
+        Optional<Balance> foundBalance = balanceRepository.findByUser(user);
 
         // then
         assertThat(foundBalance).isEmpty();
@@ -164,7 +172,7 @@ class InMemoryBalanceRepositoryTest {
 
         // then
         assertThat(savedBalance.getAmount()).isEqualTo(new BigDecimal("100000"));
-        Optional<Balance> foundBalance = balanceRepository.findByUserId(user.getId());
+        Optional<Balance> foundBalance = balanceRepository.findByUser(user);
         assertThat(foundBalance).isPresent();
         assertThat(foundBalance.get().getAmount()).isEqualTo(new BigDecimal("100000"));
     }
@@ -173,8 +181,11 @@ class InMemoryBalanceRepositoryTest {
     @MethodSource("provideInvalidUserIds")
     @DisplayName("유효하지 않은 사용자 ID들로 조회")
     void findByUserId_WithInvalidUserIds(Long invalidUserId) {
+        // given
+        User user = User.builder().id(invalidUserId).name("테스트 사용자").build();
+        
         // when
-        Optional<Balance> foundBalance = balanceRepository.findByUserId(invalidUserId);
+        Optional<Balance> foundBalance = balanceRepository.findByUser(user);
 
         // then
         assertThat(foundBalance).isEmpty();

--- a/src/test/java/kr/hhplus/be/server/unit/adapter/storage/inmemory/InMemoryBalanceRepositoryTest.java
+++ b/src/test/java/kr/hhplus/be/server/unit/adapter/storage/inmemory/InMemoryBalanceRepositoryTest.java
@@ -15,6 +15,7 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayName("InMemoryBalanceRepository 단위 테스트")
 class InMemoryBalanceRepositoryTest {
@@ -100,11 +101,130 @@ class InMemoryBalanceRepositoryTest {
         assertThat(savedBalance.getUser().getName()).isEqualTo(userName);
     }
 
+    @Test
+    @DisplayName("null 사용자 ID로 조회 시 예외 발생")
+    void findByUserId_WithNullUserId() {
+        // when & then
+        assertThatThrownBy(() -> balanceRepository.findByUserId(null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("음수 사용자 ID로 조회")
+    void findByUserId_WithNegativeUserId() {
+        // when
+        Optional<Balance> foundBalance = balanceRepository.findByUserId(-1L);
+
+        // then
+        assertThat(foundBalance).isEmpty();
+    }
+
+    @Test
+    @DisplayName("null 잔액 객체 저장 시 예외 발생")
+    void save_WithNullBalance() {
+        // when & then
+        assertThatThrownBy(() -> balanceRepository.save(null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("null 사용자가 포함된 잔액 저장 시 예외 발생")
+    void save_WithNullUser() {
+        // given
+        Balance balance = Balance.builder()
+                .user(null)
+                .amount(new BigDecimal("100000"))
+                .build();
+
+        // when & then
+        assertThatThrownBy(() -> balanceRepository.save(balance))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("동일 사용자 잔액 업데이트")
+    void save_UpdateExistingBalance() {
+        // given
+        User user = User.builder()
+                .name("테스트 사용자")
+                .build();
+        Balance originalBalance = Balance.builder()
+                .user(user)
+                .amount(new BigDecimal("50000"))
+                .build();
+        balanceRepository.save(originalBalance);
+
+        Balance updatedBalance = Balance.builder()
+                .user(user)
+                .amount(new BigDecimal("100000"))
+                .build();
+
+        // when
+        Balance savedBalance = balanceRepository.save(updatedBalance);
+
+        // then
+        assertThat(savedBalance.getAmount()).isEqualTo(new BigDecimal("100000"));
+        Optional<Balance> foundBalance = balanceRepository.findByUserId(user.getId());
+        assertThat(foundBalance).isPresent();
+        assertThat(foundBalance.get().getAmount()).isEqualTo(new BigDecimal("100000"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideInvalidUserIds")
+    @DisplayName("유효하지 않은 사용자 ID들로 조회")
+    void findByUserId_WithInvalidUserIds(Long invalidUserId) {
+        // when
+        Optional<Balance> foundBalance = balanceRepository.findByUserId(invalidUserId);
+
+        // then
+        assertThat(foundBalance).isEmpty();
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideEdgeCaseAmounts")
+    @DisplayName("극한값 잔액으로 저장")
+    void save_WithEdgeCaseAmounts(String description, String amount) {
+        // given
+        User user = User.builder()
+                .name("엣지케이스 사용자")
+                .build();
+        Balance balance = Balance.builder()
+                .user(user)
+                .amount(new BigDecimal(amount))
+                .build();
+
+        // when
+        Balance savedBalance = balanceRepository.save(balance);
+
+        // then
+        assertThat(savedBalance).isNotNull();
+        assertThat(savedBalance.getAmount()).isEqualTo(new BigDecimal(amount));
+    }
+
     private static Stream<Arguments> provideBalanceData() {
         return Stream.of(
                 Arguments.of("홍길동", "100000"),
                 Arguments.of("김철수", "250000"),
                 Arguments.of("이영희", "50000")
+        );
+    }
+
+    private static Stream<Arguments> provideInvalidUserIds() {
+        return Stream.of(
+                Arguments.of(0L),
+                Arguments.of(-1L),
+                Arguments.of(-999L),
+                Arguments.of(Long.MAX_VALUE),
+                Arguments.of(Long.MIN_VALUE)
+        );
+    }
+
+    private static Stream<Arguments> provideEdgeCaseAmounts() {
+        return Stream.of(
+                Arguments.of("최소값", "0"),
+                Arguments.of("소수점 포함", "100.50"),
+                Arguments.of("큰 금액", "999999999"),
+                Arguments.of("매우 작은 소수", "0.01")
         );
     }
 }

--- a/src/test/java/kr/hhplus/be/server/unit/adapter/storage/inmemory/InMemoryProductRepositoryTest.java
+++ b/src/test/java/kr/hhplus/be/server/unit/adapter/storage/inmemory/InMemoryProductRepositoryTest.java
@@ -101,10 +101,11 @@ class InMemoryProductRepositoryTest {
 
     @Test
     @DisplayName("페이지네이션으로 상품 조회")
-    void findAll_WithPagination() {
+    void findAllWithPagination_Success() {
         // given
         for (int i = 1; i <= 15; i++) {
             Product product = Product.builder()
+                    .id((long) i)
                     .name("상품" + i)
                     .price(new BigDecimal("100000"))
                     .stock(10)
@@ -114,7 +115,7 @@ class InMemoryProductRepositoryTest {
         }
 
         // when
-        List<Product> products = productRepository.findAll(10, 0);
+        List<Product> products = productRepository.findAllWithPagination(10, 0);
 
         // then
         assertThat(products).hasSize(10);
@@ -122,10 +123,11 @@ class InMemoryProductRepositoryTest {
 
     @Test
     @DisplayName("오프셋이 있는 페이지네이션")
-    void findAll_WithOffset() {
+    void findAllWithPagination_WithOffset() {
         // given
         for (int i = 1; i <= 15; i++) {
             Product product = Product.builder()
+                    .id((long) i)
                     .name("상품" + i)
                     .price(new BigDecimal("100000"))
                     .stock(10)
@@ -135,7 +137,7 @@ class InMemoryProductRepositoryTest {
         }
 
         // when
-        List<Product> products = productRepository.findAll(5, 10);
+        List<Product> products = productRepository.findAllWithPagination(5, 10);
 
         // then
         assertThat(products).hasSize(5);
@@ -240,7 +242,7 @@ class InMemoryProductRepositoryTest {
         }
 
         // when
-        List<Product> allProducts = productRepository.findAll(productCount, 0);
+        List<Product> allProducts = productRepository.findAllWithPagination(productCount, 0);
 
         // then
         assertThat(allProducts).hasSize(productCount);
@@ -259,15 +261,15 @@ class InMemoryProductRepositoryTest {
         productRepository.save(product);
 
         // when & then - 음수 limit
-        List<Product> result1 = productRepository.findAll(-1, 0);
+        List<Product> result1 = productRepository.findAllWithPagination(-1, 0);
         assertThat(result1).isEmpty();
 
         // when & then - 음수 offset
-        List<Product> result2 = productRepository.findAll(10, -1);
+        List<Product> result2 = productRepository.findAllWithPagination(10, -1);
         assertThat(result2).isEmpty();
 
         // when & then - 0 limit
-        List<Product> result3 = productRepository.findAll(0, 0);
+        List<Product> result3 = productRepository.findAllWithPagination(0, 0);
         assertThat(result3).isEmpty();
     }
 

--- a/src/test/java/kr/hhplus/be/server/unit/controller/BalanceControllerTest.java
+++ b/src/test/java/kr/hhplus/be/server/unit/controller/BalanceControllerTest.java
@@ -1,7 +1,7 @@
 package kr.hhplus.be.server.unit.controller;
 
 import kr.hhplus.be.server.api.controller.BalanceController;
-import kr.hhplus.be.server.api.dto.request.BalanceChargeRequest;
+import kr.hhplus.be.server.api.dto.request.BalanceRequest;
 import kr.hhplus.be.server.api.dto.response.BalanceResponse;
 import kr.hhplus.be.server.domain.entity.Balance;
 import kr.hhplus.be.server.domain.entity.User;
@@ -51,7 +51,7 @@ class BalanceControllerTest {
         // given
         Long userId = 1L;
         BigDecimal chargeAmount = new BigDecimal("50000");
-        BalanceChargeRequest request = new BalanceChargeRequest(userId, chargeAmount);
+        BalanceRequest request = new BalanceRequest(userId, chargeAmount);
         
         User user = User.builder().name("테스트 사용자").build();
         Balance balance = Balance.builder()
@@ -100,7 +100,7 @@ class BalanceControllerTest {
     @DisplayName("다양한 충전 금액으로 잔액 충전")
     void chargeBalance_WithDifferentAmounts(Long userId, String chargeAmount) {
         // given
-        BalanceChargeRequest request = new BalanceChargeRequest(userId, new BigDecimal(chargeAmount));
+        BalanceRequest request = new BalanceRequest(userId, new BigDecimal(chargeAmount));
         
         User user = User.builder().name("테스트 사용자").build();
         Balance balance = Balance.builder()
@@ -147,7 +147,7 @@ class BalanceControllerTest {
         // given
         Long userId = 999L;
         BigDecimal chargeAmount = new BigDecimal("50000");
-        BalanceChargeRequest request = new BalanceChargeRequest(userId, chargeAmount);
+        BalanceRequest request = new BalanceRequest(userId, chargeAmount);
         
         when(chargeBalanceUseCase.execute(userId, chargeAmount))
                 .thenThrow(new BalanceException.InvalidUser());
@@ -164,7 +164,7 @@ class BalanceControllerTest {
         // given
         Long userId = 1L;
         BigDecimal invalidAmount = new BigDecimal("-10000");
-        BalanceChargeRequest request = new BalanceChargeRequest(userId, invalidAmount);
+        BalanceRequest request = new BalanceRequest(userId, invalidAmount);
         
         when(chargeBalanceUseCase.execute(userId, invalidAmount))
                 .thenThrow(new BalanceException.InvalidAmount());
@@ -181,7 +181,7 @@ class BalanceControllerTest {
         // given
         Long userId = 1L;
         BigDecimal chargeAmount = new BigDecimal("50000");
-        BalanceChargeRequest request = new BalanceChargeRequest(userId, chargeAmount);
+        BalanceRequest request = new BalanceRequest(userId, chargeAmount);
         
         when(chargeBalanceUseCase.execute(userId, chargeAmount))
                 .thenThrow(new BalanceException.ConcurrencyConflict());
@@ -227,7 +227,7 @@ class BalanceControllerTest {
     @DisplayName("비정상 충전 데이터로 예외 발생")
     void chargeBalance_WithInvalidData(String description, Long userId, String amount, Class<? extends Exception> expectedException) {
         // given
-        BalanceChargeRequest request = new BalanceChargeRequest(userId, new BigDecimal(amount));
+        BalanceRequest request = new BalanceRequest(userId, new BigDecimal(amount));
         
         when(chargeBalanceUseCase.execute(userId, new BigDecimal(amount)))
                 .thenThrow(expectedException);

--- a/src/test/java/kr/hhplus/be/server/unit/controller/BalanceControllerTest.java
+++ b/src/test/java/kr/hhplus/be/server/unit/controller/BalanceControllerTest.java
@@ -3,31 +3,45 @@ package kr.hhplus.be.server.unit.controller;
 import kr.hhplus.be.server.api.controller.BalanceController;
 import kr.hhplus.be.server.api.dto.request.BalanceChargeRequest;
 import kr.hhplus.be.server.api.dto.response.BalanceResponse;
+import kr.hhplus.be.server.domain.entity.Balance;
+import kr.hhplus.be.server.domain.entity.User;
 import kr.hhplus.be.server.domain.usecase.balance.ChargeBalanceUseCase;
 import kr.hhplus.be.server.domain.usecase.balance.GetBalanceUseCase;
+import kr.hhplus.be.server.domain.exception.BalanceException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.ResponseEntity;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doThrow;
 
 @DisplayName("BalanceController 단위 테스트")
 class BalanceControllerTest {
 
     private BalanceController balanceController;
+    
+    @Mock
     private ChargeBalanceUseCase chargeBalanceUseCase;
+    
+    @Mock
     private GetBalanceUseCase getBalanceUseCase;
 
     @BeforeEach
     void setUp() {
-        chargeBalanceUseCase = new ChargeBalanceUseCase(null, null, null, null);
-        getBalanceUseCase = new GetBalanceUseCase(null, null, null);
+        MockitoAnnotations.openMocks(this);
         balanceController = new BalanceController(chargeBalanceUseCase, getBalanceUseCase);
     }
 
@@ -38,6 +52,14 @@ class BalanceControllerTest {
         Long userId = 1L;
         BigDecimal chargeAmount = new BigDecimal("50000");
         BalanceChargeRequest request = new BalanceChargeRequest(userId, chargeAmount);
+        
+        User user = User.builder().name("테스트 사용자").build();
+        Balance balance = Balance.builder()
+                .user(user)
+                .amount(new BigDecimal("150000"))
+                .build();
+        
+        when(chargeBalanceUseCase.execute(userId, chargeAmount)).thenReturn(balance);
 
         // when
         BalanceResponse response = balanceController.chargeBalance(request);
@@ -45,7 +67,7 @@ class BalanceControllerTest {
         // then
         assertThat(response).isNotNull();
         assertThat(response.userId()).isEqualTo(userId);
-        assertThat(response.amount()).isEqualTo(chargeAmount);
+        assertThat(response.amount()).isEqualTo(new BigDecimal("150000"));
         assertThat(response.updatedAt()).isNotNull();
     }
 
@@ -54,6 +76,14 @@ class BalanceControllerTest {
     void getBalance_Success() {
         // given
         Long userId = 1L;
+        
+        User user = User.builder().name("테스트 사용자").build();
+        Balance balance = Balance.builder()
+                .user(user)
+                .amount(new BigDecimal("100000"))
+                .build();
+        
+        when(getBalanceUseCase.execute(userId)).thenReturn(Optional.of(balance));
 
         // when
         BalanceResponse response = balanceController.getBalance(userId);
@@ -61,7 +91,7 @@ class BalanceControllerTest {
         // then
         assertThat(response).isNotNull();
         assertThat(response.userId()).isEqualTo(userId);
-        assertThat(response.amount()).isEqualTo(new BigDecimal("50000"));
+        assertThat(response.amount()).isEqualTo(new BigDecimal("100000"));
         assertThat(response.updatedAt()).isNotNull();
     }
 
@@ -71,6 +101,14 @@ class BalanceControllerTest {
     void chargeBalance_WithDifferentAmounts(Long userId, String chargeAmount) {
         // given
         BalanceChargeRequest request = new BalanceChargeRequest(userId, new BigDecimal(chargeAmount));
+        
+        User user = User.builder().name("테스트 사용자").build();
+        Balance balance = Balance.builder()
+                .user(user)
+                .amount(new BigDecimal(chargeAmount))
+                .build();
+        
+        when(chargeBalanceUseCase.execute(userId, new BigDecimal(chargeAmount))).thenReturn(balance);
 
         // when
         BalanceResponse response = balanceController.chargeBalance(request);
@@ -85,6 +123,15 @@ class BalanceControllerTest {
     @MethodSource("provideUserIds")
     @DisplayName("다양한 사용자 ID로 잔액 조회")
     void getBalance_WithDifferentUserIds(Long userId) {
+        // given
+        User user = User.builder().name("테스트 사용자").build();
+        Balance balance = Balance.builder()
+                .user(user)
+                .amount(new BigDecimal("50000"))
+                .build();
+        
+        when(getBalanceUseCase.execute(userId)).thenReturn(Optional.of(balance));
+        
         // when
         BalanceResponse response = balanceController.getBalance(userId);
 
@@ -92,6 +139,114 @@ class BalanceControllerTest {
         assertThat(response).isNotNull();
         assertThat(response.userId()).isEqualTo(userId);
         assertThat(response.amount()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자 잔액 충전 시 예외 발생")
+    void chargeBalance_UserNotFound() {
+        // given
+        Long userId = 999L;
+        BigDecimal chargeAmount = new BigDecimal("50000");
+        BalanceChargeRequest request = new BalanceChargeRequest(userId, chargeAmount);
+        
+        when(chargeBalanceUseCase.execute(userId, chargeAmount))
+                .thenThrow(new BalanceException.InvalidUser());
+
+        // when & then
+        assertThatThrownBy(() -> balanceController.chargeBalance(request))
+                .isInstanceOf(BalanceException.InvalidUser.class)
+                .hasMessage("Invalid user ID");
+    }
+
+    @Test
+    @DisplayName("비정상 충전 금액으로 인한 예외 발생")
+    void chargeBalance_InvalidAmount() {
+        // given
+        Long userId = 1L;
+        BigDecimal invalidAmount = new BigDecimal("-10000");
+        BalanceChargeRequest request = new BalanceChargeRequest(userId, invalidAmount);
+        
+        when(chargeBalanceUseCase.execute(userId, invalidAmount))
+                .thenThrow(new BalanceException.InvalidAmount());
+
+        // when & then
+        assertThatThrownBy(() -> balanceController.chargeBalance(request))
+                .isInstanceOf(BalanceException.InvalidAmount.class)
+                .hasMessage("Amount must be between 1,000 and 1,000,000");
+    }
+
+    @Test
+    @DisplayName("동시성 충돌로 인한 예외 발생")
+    void chargeBalance_ConcurrencyConflict() {
+        // given
+        Long userId = 1L;
+        BigDecimal chargeAmount = new BigDecimal("50000");
+        BalanceChargeRequest request = new BalanceChargeRequest(userId, chargeAmount);
+        
+        when(chargeBalanceUseCase.execute(userId, chargeAmount))
+                .thenThrow(new BalanceException.ConcurrencyConflict());
+
+        // when & then
+        assertThatThrownBy(() -> balanceController.chargeBalance(request))
+                .isInstanceOf(BalanceException.ConcurrencyConflict.class)
+                .hasMessage("Concurrent balance update conflict");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자 잔액 조회")
+    void getBalance_UserNotFound() {
+        // given
+        Long userId = 999L;
+        
+        when(getBalanceUseCase.execute(userId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> balanceController.getBalance(userId))
+                .isInstanceOf(BalanceException.InvalidUser.class)
+                .hasMessage("Invalid user ID");
+    }
+
+    @Test
+    @DisplayName("null 사용자 ID로 잔액 조회")
+    void getBalance_WithNullUserId() {
+        // when & then
+        assertThatThrownBy(() -> balanceController.getBalance(null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("null 요청으로 잔액 충전")
+    void chargeBalance_WithNullRequest() {
+        // when & then
+        assertThatThrownBy(() -> balanceController.chargeBalance(null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideInvalidChargeData")
+    @DisplayName("비정상 충전 데이터로 예외 발생")
+    void chargeBalance_WithInvalidData(String description, Long userId, String amount, Class<? extends Exception> expectedException) {
+        // given
+        BalanceChargeRequest request = new BalanceChargeRequest(userId, new BigDecimal(amount));
+        
+        when(chargeBalanceUseCase.execute(userId, new BigDecimal(amount)))
+                .thenThrow(expectedException);
+
+        // when & then
+        assertThatThrownBy(() -> balanceController.chargeBalance(request))
+                .isInstanceOf(expectedException);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideInvalidUserIds")
+    @DisplayName("비정상 사용자 ID로 잔액 조회")
+    void getBalance_WithInvalidUserIds(Long invalidUserId) {
+        // given
+        when(getBalanceUseCase.execute(invalidUserId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> balanceController.getBalance(invalidUserId))
+                .isInstanceOf(BalanceException.InvalidUser.class);
     }
 
     private static Stream<Arguments> provideChargeData() {
@@ -107,6 +262,22 @@ class BalanceControllerTest {
                 Arguments.of(1L),
                 Arguments.of(100L),
                 Arguments.of(999L)
+        );
+    }
+
+    private static Stream<Arguments> provideInvalidChargeData() {
+        return Stream.of(
+                Arguments.of("음수 금액", 1L, "-10000", BalanceException.InvalidAmount.class),
+                Arguments.of("최소 금액 미만", 1L, "500", BalanceException.InvalidAmount.class),
+                Arguments.of("최대 금액 초과", 1L, "2000000", BalanceException.InvalidAmount.class)
+        );
+    }
+
+    private static Stream<Arguments> provideInvalidUserIds() {
+        return Stream.of(
+                Arguments.of(-1L),
+                Arguments.of(0L),
+                Arguments.of(Long.MAX_VALUE)
         );
     }
 }

--- a/src/test/java/kr/hhplus/be/server/unit/controller/CouponControllerTest.java
+++ b/src/test/java/kr/hhplus/be/server/unit/controller/CouponControllerTest.java
@@ -1,6 +1,7 @@
 package kr.hhplus.be.server.unit.controller;
 
 import kr.hhplus.be.server.api.controller.CouponController;
+import kr.hhplus.be.server.api.dto.request.CouponRequest;
 import kr.hhplus.be.server.api.dto.response.CouponResponse;
 import kr.hhplus.be.server.domain.usecase.coupon.AcquireCouponUseCase;
 import kr.hhplus.be.server.domain.usecase.coupon.GetCouponListUseCase;
@@ -39,7 +40,8 @@ class CouponControllerTest {
         Long couponId = 1L;
 
         // when
-        CouponResponse response = couponController.acquireCoupon(userId, couponId);
+        CouponRequest request = new CouponRequest(userId, couponId);
+        CouponResponse response = couponController.acquireCoupon(request);
 
         // then
         assertThat(response).isNotNull();
@@ -58,7 +60,8 @@ class CouponControllerTest {
         int offset = 0;
 
         // when
-        List<CouponResponse> response = couponController.getCoupons(userId, limit, offset);
+        CouponRequest request = new CouponRequest(limit, offset);
+        List<CouponResponse> response = couponController.getCoupons(userId, request);
 
         // then
         assertThat(response).isNotNull();
@@ -72,7 +75,8 @@ class CouponControllerTest {
     @DisplayName("다양한 쿠폰으로 발급 테스트")
     void acquireCoupon_WithDifferentCoupons(Long userId, Long couponId) {
         // when
-        CouponResponse response = couponController.acquireCoupon(userId, couponId);
+        CouponRequest request = new CouponRequest(userId, couponId);
+        CouponResponse response = couponController.acquireCoupon(request);
 
         // then
         assertThat(response).isNotNull();
@@ -86,7 +90,8 @@ class CouponControllerTest {
     @DisplayName("다양한 페이지네이션으로 쿠폰 조회")
     void getCoupons_WithDifferentPagination(Long userId, int limit, int offset) {
         // when
-        List<CouponResponse> response = couponController.getCoupons(userId, limit, offset);
+        CouponRequest request = new CouponRequest(limit, offset);
+        List<CouponResponse> response = couponController.getCoupons(userId, request);
 
         // then
         assertThat(response).isNotNull();

--- a/src/test/java/kr/hhplus/be/server/unit/controller/OrderControllerTest.java
+++ b/src/test/java/kr/hhplus/be/server/unit/controller/OrderControllerTest.java
@@ -5,33 +5,53 @@ import kr.hhplus.be.server.api.controller.OrderController;
 import kr.hhplus.be.server.api.dto.request.CreateOrderRequest;
 import kr.hhplus.be.server.api.dto.response.OrderResponse;
 import kr.hhplus.be.server.api.dto.response.PaymentResponse;
+import kr.hhplus.be.server.domain.entity.Order;
+import kr.hhplus.be.server.domain.entity.Payment;
+import kr.hhplus.be.server.domain.entity.User;
 import kr.hhplus.be.server.domain.usecase.order.CreateOrderUseCase;
 import kr.hhplus.be.server.domain.usecase.order.PayOrderUseCase;
+import kr.hhplus.be.server.domain.exception.OrderException;
+import kr.hhplus.be.server.domain.exception.PaymentException;
+import kr.hhplus.be.server.domain.exception.ProductException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyMap;
 
 @DisplayName("OrderController 단위 테스트")
 class OrderControllerTest {
 
     private OrderController orderController;
+    
+    @Mock
     private CreateOrderUseCase createOrderUseCase;
+    
+    @Mock
     private PayOrderUseCase payOrderUseCase;
 
     @BeforeEach
     void setUp() {
-        createOrderUseCase = new CreateOrderUseCase(null, null, null, null, null, null);
-        payOrderUseCase = new PayOrderUseCase(null, null, null, null, null, null, null, null, null);
+        MockitoAnnotations.openMocks(this);
         orderController = new OrderController(createOrderUseCase, payOrderUseCase);
     }
 
@@ -43,6 +63,14 @@ class OrderControllerTest {
         List<Long> productIds = List.of(1L, 2L);
         List<Long> couponIds = List.of(1L);
         CreateOrderRequest request = new CreateOrderRequest(userId, productIds, couponIds);
+        
+        User user = User.builder().name("테스트 사용자").build();
+        Order order = Order.builder()
+                .user(user)
+                .totalAmount(new BigDecimal("100000"))
+                .build();
+        
+        when(createOrderUseCase.execute(anyLong(), anyMap())).thenReturn(order);
 
         // when
         OrderResponse response = orderController.createOrder(request);
@@ -59,6 +87,14 @@ class OrderControllerTest {
     void createOrder_WithDifferentData(Long userId, List<Long> productIds, List<Long> couponIds) {
         // given
         CreateOrderRequest request = new CreateOrderRequest(userId, productIds, couponIds);
+        
+        User user = User.builder().name("테스트 사용자").build();
+        Order order = Order.builder()
+                .user(user)
+                .totalAmount(new BigDecimal("50000"))
+                .build();
+        
+        when(createOrderUseCase.execute(anyLong(), anyMap())).thenReturn(order);
 
         // when
         OrderResponse response = orderController.createOrder(request);
@@ -73,9 +109,21 @@ class OrderControllerTest {
     void payOrder_Success() {
         // given
         Long orderId = 1L;
+        
+        User user = User.builder().name("테스트 사용자").build();
+        Order order = Order.builder()
+                .user(user)
+                .totalAmount(new BigDecimal("100000"))
+                .build();
+        Payment payment = Payment.builder()
+                .order(order)
+                .amount(new BigDecimal("100000"))
+                .build();
+        
+        when(payOrderUseCase.execute(orderId, 1L, null)).thenReturn(payment);
 
         // when
-        PaymentResponse response = orderController.payOrder(orderId);
+        PaymentResponse response = orderController.payOrder(orderId, 1L, null);
 
         // then
         assertThat(response).isNotNull();
@@ -87,12 +135,138 @@ class OrderControllerTest {
     @MethodSource("provideOrderIds")
     @DisplayName("다양한 주문 ID로 결제")
     void payOrder_WithDifferentOrderIds(Long orderId) {
+        // given
+        User user = User.builder().name("테스트 사용자").build();
+        Order order = Order.builder()
+                .user(user)
+                .totalAmount(new BigDecimal("75000"))
+                .build();
+        Payment payment = Payment.builder()
+                .order(order)
+                .amount(new BigDecimal("75000"))
+                .build();
+        
+        when(payOrderUseCase.execute(orderId, 1L, null)).thenReturn(payment);
+        
         // when
-        PaymentResponse response = orderController.payOrder(orderId);
+        PaymentResponse response = orderController.payOrder(orderId, 1L, null);
 
         // then
         assertThat(response).isNotNull();
         assertThat(response.orderId()).isEqualTo(orderId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자로 주문 생성 시 예외 발생")
+    void createOrder_UserNotFound() {
+        // given
+        Long userId = 999L;
+        List<Long> productIds = List.of(1L);
+        List<Long> couponIds = List.of();
+        CreateOrderRequest request = new CreateOrderRequest(userId, productIds, couponIds);
+        
+        when(createOrderUseCase.execute(anyLong(), anyMap()))
+                .thenThrow(new OrderException.InvalidUser());
+
+        // when & then
+        assertThatThrownBy(() -> orderController.createOrder(request))
+                .isInstanceOf(OrderException.InvalidUser.class)
+                .hasMessage("Invalid user ID");
+    }
+
+    @Test
+    @DisplayName("빈 상품 리스트로 주문 생성 시 예외 발생")
+    void createOrder_EmptyProductList() {
+        // given
+        Long userId = 1L;
+        List<Long> productIds = Collections.emptyList();
+        List<Long> couponIds = List.of();
+        CreateOrderRequest request = new CreateOrderRequest(userId, productIds, couponIds);
+        
+        when(createOrderUseCase.execute(anyLong(), anyMap()))
+                .thenThrow(new IllegalArgumentException("Order must contain at least one item"));
+
+        // when & then
+        assertThatThrownBy(() -> orderController.createOrder(request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Order must contain at least one item");
+    }
+
+    @Test
+    @DisplayName("재고 부족 상품으로 주문 생성 시 예외 발생")
+    void createOrder_InsufficientStock() {
+        // given
+        Long userId = 1L;
+        List<Long> productIds = List.of(1L);
+        List<Long> couponIds = List.of();
+        CreateOrderRequest request = new CreateOrderRequest(userId, productIds, couponIds);
+        
+        when(createOrderUseCase.execute(anyLong(), anyMap()))
+                .thenThrow(new ProductException.OutOfStock());
+
+        // when & then
+        assertThatThrownBy(() -> orderController.createOrder(request))
+                .isInstanceOf(ProductException.OutOfStock.class)
+                .hasMessage("Product out of stock");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 주문 결제 시 예외 발생")
+    void payOrder_OrderNotFound() {
+        // given
+        Long orderId = 999L;
+        
+        when(payOrderUseCase.execute(orderId, null, null))
+                .thenThrow(new PaymentException.OrderNotFound());
+
+        // when & then
+        assertThatThrownBy(() -> orderController.payOrder(orderId, null, null))
+                .isInstanceOf(PaymentException.OrderNotFound.class)
+                .hasMessage("Order not found");
+    }
+
+    @Test
+    @DisplayName("잔액 부족으로 결제 시 예외 발생")
+    void payOrder_InsufficientBalance() {
+        // given
+        Long orderId = 1L;
+        
+        when(payOrderUseCase.execute(orderId, null, null))
+                .thenThrow(new PaymentException.InsufficientBalance());
+
+        // when & then
+        assertThatThrownBy(() -> orderController.payOrder(orderId, null, null))
+                .isInstanceOf(PaymentException.InsufficientBalance.class)
+                .hasMessage("Insufficient balance");
+    }
+
+    @Test
+    @DisplayName("null 요청으로 주문 생성")
+    void createOrder_WithNullRequest() {
+        // when & then
+        assertThatThrownBy(() -> orderController.createOrder(null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("null 주문 ID로 결제")
+    void payOrder_WithNullOrderId() {
+        // when & then
+        assertThatThrownBy(() -> orderController.payOrder(null, null, null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideInvalidOrderIds")
+    @DisplayName("비정상 주문 ID로 결제")
+    void payOrder_WithInvalidOrderIds(Long invalidOrderId) {
+        // given
+        when(payOrderUseCase.execute(invalidOrderId, null, null))
+                .thenThrow(new PaymentException.OrderNotFound());
+
+        // when & then
+        assertThatThrownBy(() -> orderController.payOrder(invalidOrderId, null, null))
+                .isInstanceOf(PaymentException.OrderNotFound.class);
     }
 
     private static Stream<Arguments> provideOrderData() {
@@ -108,6 +282,14 @@ class OrderControllerTest {
                 Arguments.of(1L),
                 Arguments.of(100L),
                 Arguments.of(999L)
+        );
+    }
+
+    private static Stream<Arguments> provideInvalidOrderIds() {
+        return Stream.of(
+                Arguments.of(-1L),
+                Arguments.of(0L),
+                Arguments.of(Long.MAX_VALUE)
         );
     }
 } 

--- a/src/test/java/kr/hhplus/be/server/unit/controller/OrderControllerTest.java
+++ b/src/test/java/kr/hhplus/be/server/unit/controller/OrderControllerTest.java
@@ -2,7 +2,7 @@ package kr.hhplus.be.server.unit.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.hhplus.be.server.api.controller.OrderController;
-import kr.hhplus.be.server.api.dto.request.CreateOrderRequest;
+import kr.hhplus.be.server.api.dto.request.OrderRequest;
 import kr.hhplus.be.server.api.dto.response.OrderResponse;
 import kr.hhplus.be.server.api.dto.response.PaymentResponse;
 import kr.hhplus.be.server.domain.entity.Order;
@@ -62,7 +62,7 @@ class OrderControllerTest {
         Long userId = 1L;
         List<Long> productIds = List.of(1L, 2L);
         List<Long> couponIds = List.of(1L);
-        CreateOrderRequest request = new CreateOrderRequest(userId, productIds, couponIds);
+        OrderRequest request = new OrderRequest(userId, productIds, couponIds);
         
         User user = User.builder().name("테스트 사용자").build();
         Order order = Order.builder()
@@ -86,7 +86,7 @@ class OrderControllerTest {
     @DisplayName("다양한 주문 데이터로 주문 생성")
     void createOrder_WithDifferentData(Long userId, List<Long> productIds, List<Long> couponIds) {
         // given
-        CreateOrderRequest request = new CreateOrderRequest(userId, productIds, couponIds);
+        OrderRequest request = new OrderRequest(userId, productIds, couponIds);
         
         User user = User.builder().name("테스트 사용자").build();
         Order order = Order.builder()
@@ -123,7 +123,8 @@ class OrderControllerTest {
         when(payOrderUseCase.execute(orderId, 1L, null)).thenReturn(payment);
 
         // when
-        PaymentResponse response = orderController.payOrder(orderId, 1L, null);
+        OrderRequest request = new OrderRequest(1L, null);
+        PaymentResponse response = orderController.payOrder(orderId, request);
 
         // then
         assertThat(response).isNotNull();
@@ -149,7 +150,8 @@ class OrderControllerTest {
         when(payOrderUseCase.execute(orderId, 1L, null)).thenReturn(payment);
         
         // when
-        PaymentResponse response = orderController.payOrder(orderId, 1L, null);
+        OrderRequest request = new OrderRequest(1L, null);
+        PaymentResponse response = orderController.payOrder(orderId, request);
 
         // then
         assertThat(response).isNotNull();
@@ -163,7 +165,7 @@ class OrderControllerTest {
         Long userId = 999L;
         List<Long> productIds = List.of(1L);
         List<Long> couponIds = List.of();
-        CreateOrderRequest request = new CreateOrderRequest(userId, productIds, couponIds);
+        OrderRequest request = new OrderRequest(userId, productIds, couponIds);
         
         when(createOrderUseCase.execute(anyLong(), anyMap()))
                 .thenThrow(new OrderException.InvalidUser());
@@ -181,7 +183,7 @@ class OrderControllerTest {
         Long userId = 1L;
         List<Long> productIds = Collections.emptyList();
         List<Long> couponIds = List.of();
-        CreateOrderRequest request = new CreateOrderRequest(userId, productIds, couponIds);
+        OrderRequest request = new OrderRequest(userId, productIds, couponIds);
         
         when(createOrderUseCase.execute(anyLong(), anyMap()))
                 .thenThrow(new IllegalArgumentException("Order must contain at least one item"));
@@ -199,7 +201,7 @@ class OrderControllerTest {
         Long userId = 1L;
         List<Long> productIds = List.of(1L);
         List<Long> couponIds = List.of();
-        CreateOrderRequest request = new CreateOrderRequest(userId, productIds, couponIds);
+        OrderRequest request = new OrderRequest(userId, productIds, couponIds);
         
         when(createOrderUseCase.execute(anyLong(), anyMap()))
                 .thenThrow(new ProductException.OutOfStock());
@@ -220,7 +222,8 @@ class OrderControllerTest {
                 .thenThrow(new PaymentException.OrderNotFound());
 
         // when & then
-        assertThatThrownBy(() -> orderController.payOrder(orderId, null, null))
+        OrderRequest request = new OrderRequest(null, null);
+        assertThatThrownBy(() -> orderController.payOrder(orderId, request))
                 .isInstanceOf(PaymentException.OrderNotFound.class)
                 .hasMessage("Order not found");
     }
@@ -235,7 +238,8 @@ class OrderControllerTest {
                 .thenThrow(new PaymentException.InsufficientBalance());
 
         // when & then
-        assertThatThrownBy(() -> orderController.payOrder(orderId, null, null))
+        OrderRequest request = new OrderRequest(null, null);
+        assertThatThrownBy(() -> orderController.payOrder(orderId, request))
                 .isInstanceOf(PaymentException.InsufficientBalance.class)
                 .hasMessage("Insufficient balance");
     }
@@ -252,7 +256,8 @@ class OrderControllerTest {
     @DisplayName("null 주문 ID로 결제")
     void payOrder_WithNullOrderId() {
         // when & then
-        assertThatThrownBy(() -> orderController.payOrder(null, null, null))
+        OrderRequest request = new OrderRequest(null, null);
+        assertThatThrownBy(() -> orderController.payOrder(null, request))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -265,7 +270,8 @@ class OrderControllerTest {
                 .thenThrow(new PaymentException.OrderNotFound());
 
         // when & then
-        assertThatThrownBy(() -> orderController.payOrder(invalidOrderId, null, null))
+        OrderRequest request = new OrderRequest(null, null);
+        assertThatThrownBy(() -> orderController.payOrder(invalidOrderId, request))
                 .isInstanceOf(PaymentException.OrderNotFound.class);
     }
 

--- a/src/test/java/kr/hhplus/be/server/unit/controller/ProductControllerTest.java
+++ b/src/test/java/kr/hhplus/be/server/unit/controller/ProductControllerTest.java
@@ -1,6 +1,7 @@
 package kr.hhplus.be.server.unit.controller;
 
 import kr.hhplus.be.server.api.controller.ProductController;
+import kr.hhplus.be.server.api.dto.request.ProductRequest;
 import kr.hhplus.be.server.api.dto.response.ProductResponse;
 import kr.hhplus.be.server.domain.usecase.product.GetProductListUseCase;
 import kr.hhplus.be.server.domain.usecase.product.GetPopularProductListUseCase;
@@ -33,8 +34,11 @@ class ProductControllerTest {
     @Test
     @DisplayName("상품 목록 조회 API 성공")
     void getProducts_Success() {
-        // given & when
-        List<ProductResponse> response = productController.getProducts(10, 0);
+        // given
+        ProductRequest request = new ProductRequest(10, 0);
+        
+        // when
+        List<ProductResponse> response = productController.getProductList(request);
 
         // then
         assertThat(response).hasSize(3);
@@ -47,8 +51,11 @@ class ProductControllerTest {
     @MethodSource("providePaginationData")
     @DisplayName("다양한 페이지네이션으로 상품 조회")
     void getProducts_WithDifferentPagination(int limit, int offset) {
+        // given
+        ProductRequest request = new ProductRequest(limit, offset);
+        
         // when
-        List<ProductResponse> response = productController.getProducts(limit, offset);
+        List<ProductResponse> response = productController.getProductList(request);
 
         // then
         assertThat(response).hasSize(3); // 하드코딩된 응답이므로 항상 3개
@@ -57,8 +64,11 @@ class ProductControllerTest {
     @Test
     @DisplayName("인기 상품 조회 API 성공")
     void getPopularProducts_Success() {
-        // given & when
-        List<ProductResponse> response = productController.getPopularProducts(3);
+        // given
+        ProductRequest request = new ProductRequest(3);
+        
+        // when
+        List<ProductResponse> response = productController.getPopularProducts(request);
 
         // then
         assertThat(response).hasSize(5);
@@ -70,8 +80,11 @@ class ProductControllerTest {
     @Test
     @DisplayName("기본 페이지네이션으로 상품 조회")
     void getProducts_WithDefaultPagination() {
+        // given
+        ProductRequest request = new ProductRequest(10, 0);
+        
         // when
-        List<ProductResponse> response = productController.getProducts(10, 0);
+        List<ProductResponse> response = productController.getProductList(request);
 
         // then
         assertThat(response).hasSize(3);

--- a/src/test/java/kr/hhplus/be/server/unit/controller/ProductControllerTest.java
+++ b/src/test/java/kr/hhplus/be/server/unit/controller/ProductControllerTest.java
@@ -58,7 +58,7 @@ class ProductControllerTest {
     @DisplayName("인기 상품 조회 API 성공")
     void getPopularProducts_Success() {
         // given & when
-        List<ProductResponse> response = productController.getPopularProducts();
+        List<ProductResponse> response = productController.getPopularProducts(3);
 
         // then
         assertThat(response).hasSize(5);

--- a/src/test/java/kr/hhplus/be/server/unit/usecase/AcquireCouponUseCaseTest.java
+++ b/src/test/java/kr/hhplus/be/server/unit/usecase/AcquireCouponUseCaseTest.java
@@ -76,7 +76,7 @@ class AcquireCouponUseCaseTest {
         
         when(userRepositoryPort.findById(userId)).thenReturn(Optional.of(user));
         when(couponRepositoryPort.findById(couponId)).thenReturn(Optional.of(coupon));
-        when(couponHistoryRepositoryPort.existsByUserIdAndCouponId(userId, couponId)).thenReturn(false);
+        when(couponHistoryRepositoryPort.existsByUserAndCoupon(user, coupon)).thenReturn(false);
         when(couponHistoryRepositoryPort.save(any(CouponHistory.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         // when
@@ -109,7 +109,7 @@ class AcquireCouponUseCaseTest {
         
         when(userRepositoryPort.findById(userId)).thenReturn(Optional.of(user));
         when(couponRepositoryPort.findById(couponId)).thenReturn(Optional.of(coupon));
-        when(couponHistoryRepositoryPort.existsByUserIdAndCouponId(userId, couponId)).thenReturn(false);
+        when(couponHistoryRepositoryPort.existsByUserAndCoupon(user, coupon)).thenReturn(false);
         when(couponHistoryRepositoryPort.save(any(CouponHistory.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         // when
@@ -207,7 +207,7 @@ class AcquireCouponUseCaseTest {
         
         when(userRepositoryPort.findById(userId)).thenReturn(Optional.of(user));
         when(couponRepositoryPort.findById(couponId)).thenReturn(Optional.of(outOfStockCoupon));
-        when(couponHistoryRepositoryPort.existsByUserIdAndCouponId(userId, couponId)).thenReturn(false);
+        when(couponHistoryRepositoryPort.existsByUserAndCoupon(user, outOfStockCoupon)).thenReturn(false);
 
         // when & then
         assertThatThrownBy(() -> acquireCouponUseCase.execute(userId, couponId))
@@ -237,7 +237,7 @@ class AcquireCouponUseCaseTest {
         
         when(userRepositoryPort.findById(userId)).thenReturn(Optional.of(user));
         when(couponRepositoryPort.findById(couponId)).thenReturn(Optional.of(coupon));
-        when(couponHistoryRepositoryPort.existsByUserIdAndCouponId(userId, couponId)).thenReturn(true); // 이미 발급받음
+        when(couponHistoryRepositoryPort.existsByUserAndCoupon(user, coupon)).thenReturn(true); // 이미 발급받음
 
         // when & then
         assertThatThrownBy(() -> acquireCouponUseCase.execute(userId, couponId))
@@ -291,7 +291,7 @@ class AcquireCouponUseCaseTest {
         
         when(userRepositoryPort.findById(userId)).thenReturn(Optional.of(user));
         when(couponRepositoryPort.findById(couponId)).thenReturn(Optional.of(futureStartCoupon));
-        when(couponHistoryRepositoryPort.existsByUserIdAndCouponId(userId, couponId)).thenReturn(false);
+        when(couponHistoryRepositoryPort.existsByUserAndCoupon(user, futureStartCoupon)).thenReturn(false);
 
         // when & then
         assertThatThrownBy(() -> acquireCouponUseCase.execute(userId, couponId))

--- a/src/test/java/kr/hhplus/be/server/unit/usecase/AcquireCouponUseCaseTest.java
+++ b/src/test/java/kr/hhplus/be/server/unit/usecase/AcquireCouponUseCaseTest.java
@@ -23,8 +23,11 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+
+import kr.hhplus.be.server.domain.exception.CouponException;
 
 @DisplayName("AcquireCouponUseCase 단위 테스트")
 class AcquireCouponUseCaseTest {
@@ -118,11 +121,217 @@ class AcquireCouponUseCaseTest {
         // assertThat(result.getCoupon().getCode()).isEqualTo(couponCode);
     }
 
+    @Test
+    @DisplayName("존재하지 않는 사용자 쿠폰 발급 시 예외 발생")
+    void acquireCoupon_UserNotFound() {
+        // given
+        Long userId = 999L;
+        Long couponId = 1L;
+        
+        when(userRepositoryPort.findById(userId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> acquireCouponUseCase.execute(userId, couponId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("User not found");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 쿠폰 발급 시 예외 발생")
+    void acquireCoupon_CouponNotFound() {
+        // given
+        Long userId = 1L;
+        Long couponId = 999L;
+        
+        User user = User.builder()
+                .name("테스트 사용자")
+                .build();
+        
+        when(userRepositoryPort.findById(userId)).thenReturn(Optional.of(user));
+        when(couponRepositoryPort.findById(couponId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> acquireCouponUseCase.execute(userId, couponId))
+                .isInstanceOf(CouponException.NotFound.class)
+                .hasMessage("Coupon not found");
+    }
+
+    @Test
+    @DisplayName("만료된 쿠폰 발급 시 예외 발생")
+    void acquireCoupon_ExpiredCoupon() {
+        // given
+        Long userId = 1L;
+        Long couponId = 1L;
+        
+        User user = User.builder()
+                .name("테스트 사용자")
+                .build();
+        
+        Coupon expiredCoupon = Coupon.builder()
+                .code("EXPIRED")
+                .discountRate(new BigDecimal("0.10"))
+                .maxIssuance(100)
+                .issuedCount(50)
+                .startDate(LocalDateTime.now().minusDays(10))
+                .endDate(LocalDateTime.now().minusDays(1)) // 이미 만료
+                .build();
+        
+        when(userRepositoryPort.findById(userId)).thenReturn(Optional.of(user));
+        when(couponRepositoryPort.findById(couponId)).thenReturn(Optional.of(expiredCoupon));
+
+        // when & then
+        assertThatThrownBy(() -> acquireCouponUseCase.execute(userId, couponId))
+                .isInstanceOf(CouponException.Expired.class)
+                .hasMessage("Coupon has expired");
+    }
+
+    @Test
+    @DisplayName("재고 소진된 쿠폰 발급 시 예외 발생")
+    void acquireCoupon_OutOfStock() {
+        // given
+        Long userId = 1L;
+        Long couponId = 1L;
+        
+        User user = User.builder()
+                .name("테스트 사용자")
+                .build();
+        
+        Coupon outOfStockCoupon = Coupon.builder()
+                .code("OUTOFSTOCK")
+                .discountRate(new BigDecimal("0.20"))
+                .maxIssuance(100)
+                .issuedCount(100) // 재고 소진
+                .startDate(LocalDateTime.now().minusDays(1))
+                .endDate(LocalDateTime.now().plusDays(30))
+                .build();
+        
+        when(userRepositoryPort.findById(userId)).thenReturn(Optional.of(user));
+        when(couponRepositoryPort.findById(couponId)).thenReturn(Optional.of(outOfStockCoupon));
+        when(couponHistoryRepositoryPort.existsByUserIdAndCouponId(userId, couponId)).thenReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> acquireCouponUseCase.execute(userId, couponId))
+                .isInstanceOf(CouponException.OutOfStock.class)
+                .hasMessage("Coupon stock exhausted");
+    }
+
+    @Test
+    @DisplayName("이미 발급받은 쿠폰 재발급 시 예외 발생")
+    void acquireCoupon_AlreadyAcquired() {
+        // given
+        Long userId = 1L;
+        Long couponId = 1L;
+        
+        User user = User.builder()
+                .name("테스트 사용자")
+                .build();
+        
+        Coupon coupon = Coupon.builder()
+                .code("ALREADY_ACQUIRED")
+                .discountRate(new BigDecimal("0.15"))
+                .maxIssuance(100)
+                .issuedCount(50)
+                .startDate(LocalDateTime.now().minusDays(1))
+                .endDate(LocalDateTime.now().plusDays(30))
+                .build();
+        
+        when(userRepositoryPort.findById(userId)).thenReturn(Optional.of(user));
+        when(couponRepositoryPort.findById(couponId)).thenReturn(Optional.of(coupon));
+        when(couponHistoryRepositoryPort.existsByUserIdAndCouponId(userId, couponId)).thenReturn(true); // 이미 발급받음
+
+        // when & then
+        assertThatThrownBy(() -> acquireCouponUseCase.execute(userId, couponId))
+                .isInstanceOf(CouponException.AlreadyAcquired.class)
+                .hasMessage("Coupon already acquired by user");
+    }
+
+    @Test
+    @DisplayName("null 사용자 ID로 쿠폰 발급 시 예외 발생")
+    void acquireCoupon_WithNullUserId() {
+        // given
+        Long userId = null;
+        Long couponId = 1L;
+
+        // when & then
+        assertThatThrownBy(() -> acquireCouponUseCase.execute(userId, couponId))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("null 쿠폰 ID로 쿠폰 발급 시 예외 발생")
+    void acquireCoupon_WithNullCouponId() {
+        // given
+        Long userId = 1L;
+        Long couponId = null;
+
+        // when & then
+        assertThatThrownBy(() -> acquireCouponUseCase.execute(userId, couponId))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("아직 시작되지 않은 쿠폰 발급 시 예외 발생")
+    void acquireCoupon_NotYetStarted() {
+        // given
+        Long userId = 1L;
+        Long couponId = 1L;
+        
+        User user = User.builder()
+                .name("테스트 사용자")
+                .build();
+        
+        Coupon futureStartCoupon = Coupon.builder()
+                .code("FUTURE_START")
+                .discountRate(new BigDecimal("0.25"))
+                .maxIssuance(100)
+                .issuedCount(0)
+                .startDate(LocalDateTime.now().plusDays(1)) // 아직 시작 안함
+                .endDate(LocalDateTime.now().plusDays(30))
+                .build();
+        
+        when(userRepositoryPort.findById(userId)).thenReturn(Optional.of(user));
+        when(couponRepositoryPort.findById(couponId)).thenReturn(Optional.of(futureStartCoupon));
+        when(couponHistoryRepositoryPort.existsByUserIdAndCouponId(userId, couponId)).thenReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> acquireCouponUseCase.execute(userId, couponId))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("not yet started");
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideInvalidIds")
+    @DisplayName("비정상 ID 값들로 쿠폰 발급 테스트")
+    void acquireCoupon_WithInvalidIds(Long userId, Long couponId) {
+        // when & then
+        if (userId != null && userId > 0) {
+            User user = User.builder().name("테스트").build();
+            when(userRepositoryPort.findById(userId)).thenReturn(Optional.of(user));
+        } else {
+            when(userRepositoryPort.findById(userId)).thenReturn(Optional.empty());
+        }
+        
+        when(couponRepositoryPort.findById(couponId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> acquireCouponUseCase.execute(userId, couponId))
+                .isInstanceOf(RuntimeException.class);
+    }
+
     private static Stream<Arguments> provideCouponData() {
         return Stream.of(
                 Arguments.of(1L, 1L, "WELCOME10"),
                 Arguments.of(2L, 2L, "SUMMER25"),
                 Arguments.of(3L, 3L, "VIP30")
+        );
+    }
+
+    private static Stream<Arguments> provideInvalidIds() {
+        return Stream.of(
+                Arguments.of(-1L, 1L),
+                Arguments.of(1L, -1L),
+                Arguments.of(0L, 1L),
+                Arguments.of(1L, 0L),
+                Arguments.of(999L, 999L)
         );
     }
 }

--- a/src/test/java/kr/hhplus/be/server/unit/usecase/ChargeBalanceUseCaseTest.java
+++ b/src/test/java/kr/hhplus/be/server/unit/usecase/ChargeBalanceUseCaseTest.java
@@ -21,8 +21,11 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+
+import kr.hhplus.be.server.domain.exception.BalanceException;
 
 @DisplayName("ChargeBalanceUseCase 단위 테스트")
 class ChargeBalanceUseCaseTest {
@@ -104,11 +107,191 @@ class ChargeBalanceUseCaseTest {
         // assertThat(result).isNotNull();
     }
 
+    @Test
+    @DisplayName("존재하지 않는 사용자 잔액 충전 시 예외 발생")
+    void chargeBalance_UserNotFound() {
+        // given
+        Long userId = 999L;
+        BigDecimal chargeAmount = new BigDecimal("50000");
+        
+        when(userRepositoryPort.findById(userId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> chargeBalanceUseCase.execute(userId, chargeAmount))
+                .isInstanceOf(BalanceException.InvalidUser.class)
+                .hasMessage("Invalid user ID");
+    }
+
+    @Test
+    @DisplayName("null 사용자 ID로 잔액 충전 시 예외 발생")
+    void chargeBalance_WithNullUserId() {
+        // given
+        Long userId = null;
+        BigDecimal chargeAmount = new BigDecimal("50000");
+
+        // when & then
+        assertThatThrownBy(() -> chargeBalanceUseCase.execute(userId, chargeAmount))
+                .isInstanceOf(BalanceException.InvalidUser.class);
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 충전 금액 - 음수")
+    void chargeBalance_WithNegativeAmount() {
+        // given
+        Long userId = 1L;
+        BigDecimal chargeAmount = new BigDecimal("-10000");
+        
+        User user = User.builder()
+                .name("테스트 사용자")
+                .build();
+        
+        when(userRepositoryPort.findById(userId)).thenReturn(Optional.of(user));
+
+        // when & then
+        assertThatThrownBy(() -> chargeBalanceUseCase.execute(userId, chargeAmount))
+                .isInstanceOf(BalanceException.InvalidAmount.class)
+                .hasMessage("Amount must be between 1,000 and 1,000,000");
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 충전 금액 - 최대 한도 초과")
+    void chargeBalance_WithExcessiveAmount() {
+        // given
+        Long userId = 1L;
+        BigDecimal chargeAmount = new BigDecimal("2000000"); // 100만원 초과
+        
+        User user = User.builder()
+                .name("테스트 사용자")
+                .build();
+        
+        when(userRepositoryPort.findById(userId)).thenReturn(Optional.of(user));
+
+        // when & then
+        assertThatThrownBy(() -> chargeBalanceUseCase.execute(userId, chargeAmount))
+                .isInstanceOf(BalanceException.InvalidAmount.class)
+                .hasMessage("Amount must be between 1,000 and 1,000,000");
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 충전 금액 - 최소 한도 미만")
+    void chargeBalance_WithTooSmallAmount() {
+        // given
+        Long userId = 1L;
+        BigDecimal chargeAmount = new BigDecimal("500"); // 1000원 미만
+        
+        User user = User.builder()
+                .name("테스트 사용자")
+                .build();
+        
+        when(userRepositoryPort.findById(userId)).thenReturn(Optional.of(user));
+
+        // when & then
+        assertThatThrownBy(() -> chargeBalanceUseCase.execute(userId, chargeAmount))
+                .isInstanceOf(BalanceException.InvalidAmount.class)
+                .hasMessage("Amount must be between 1,000 and 1,000,000");
+    }
+
+    @Test
+    @DisplayName("null 충전 금액")
+    void chargeBalance_WithNullAmount() {
+        // given
+        Long userId = 1L;
+        BigDecimal chargeAmount = null;
+        
+        User user = User.builder()
+                .name("테스트 사용자")
+                .build();
+        
+        when(userRepositoryPort.findById(userId)).thenReturn(Optional.of(user));
+
+        // when & then
+        assertThatThrownBy(() -> chargeBalanceUseCase.execute(userId, chargeAmount))
+                .isInstanceOf(BalanceException.InvalidAmount.class);
+    }
+
+    @Test
+    @DisplayName("동시성 충돌 시나리오")
+    void chargeBalance_ConcurrencyConflict() {
+        // given
+        Long userId = 1L;
+        BigDecimal chargeAmount = new BigDecimal("50000");
+        
+        User user = User.builder()
+                .name("테스트 사용자")
+                .build();
+        
+        Balance existingBalance = Balance.builder()
+                .user(user)
+                .amount(new BigDecimal("100000"))
+                .build();
+        
+        when(userRepositoryPort.findById(userId)).thenReturn(Optional.of(user));
+        when(balanceRepositoryPort.findByUserId(userId)).thenReturn(Optional.of(existingBalance));
+        when(balanceRepositoryPort.save(any(Balance.class))).thenThrow(new BalanceException.ConcurrencyConflict());
+
+        // when & then
+        assertThatThrownBy(() -> chargeBalanceUseCase.execute(userId, chargeAmount))
+                .isInstanceOf(BalanceException.ConcurrencyConflict.class)
+                .hasMessage("Concurrent balance update conflict");
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideInvalidUserIds")
+    @DisplayName("다양한 비정상 사용자 ID 테스트")
+    void chargeBalance_WithInvalidUserIds(Long invalidUserId) {
+        // given
+        BigDecimal chargeAmount = new BigDecimal("50000");
+        
+        when(userRepositoryPort.findById(invalidUserId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> chargeBalanceUseCase.execute(invalidUserId, chargeAmount))
+                .isInstanceOf(BalanceException.InvalidUser.class);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideInvalidAmounts")
+    @DisplayName("다양한 비정상 충전 금액 테스트")
+    void chargeBalance_WithInvalidAmounts(String description, String invalidAmount) {
+        // given
+        Long userId = 1L;
+        BigDecimal chargeAmount = new BigDecimal(invalidAmount);
+        
+        User user = User.builder()
+                .name("테스트 사용자")
+                .build();
+        
+        when(userRepositoryPort.findById(userId)).thenReturn(Optional.of(user));
+
+        // when & then
+        assertThatThrownBy(() -> chargeBalanceUseCase.execute(userId, chargeAmount))
+                .isInstanceOf(BalanceException.InvalidAmount.class);
+    }
+
     private static Stream<Arguments> provideChargeData() {
         return Stream.of(
                 Arguments.of(1L, "10000"),
                 Arguments.of(2L, "50000"),
                 Arguments.of(3L, "100000")
+        );
+    }
+
+    private static Stream<Arguments> provideInvalidUserIds() {
+        return Stream.of(
+                Arguments.of(-1L),
+                Arguments.of(0L),
+                Arguments.of(Long.MAX_VALUE),
+                Arguments.of(Long.MIN_VALUE)
+        );
+    }
+
+    private static Stream<Arguments> provideInvalidAmounts() {
+        return Stream.of(
+                Arguments.of("음수", "-1000"),
+                Arguments.of("영", "0"),
+                Arguments.of("최소값 미만", "999"),
+                Arguments.of("최대값 초과", "1000001"),
+                Arguments.of("매우 큰 값", "999999999")
         );
     }
 }

--- a/src/test/java/kr/hhplus/be/server/unit/usecase/ChargeBalanceUseCaseTest.java
+++ b/src/test/java/kr/hhplus/be/server/unit/usecase/ChargeBalanceUseCaseTest.java
@@ -69,7 +69,7 @@ class ChargeBalanceUseCaseTest {
                 .build();
         
         when(userRepositoryPort.findById(userId)).thenReturn(Optional.of(user));
-        when(balanceRepositoryPort.findByUserId(userId)).thenReturn(Optional.of(existingBalance));
+        when(balanceRepositoryPort.findByUser(user)).thenReturn(Optional.of(existingBalance));
         when(balanceRepositoryPort.save(any(Balance.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         // when
@@ -96,7 +96,7 @@ class ChargeBalanceUseCaseTest {
                 .build();
         
         when(userRepositoryPort.findById(userId)).thenReturn(Optional.of(user));
-        when(balanceRepositoryPort.findByUserId(userId)).thenReturn(Optional.of(existingBalance));
+        when(balanceRepositoryPort.findByUser(user)).thenReturn(Optional.of(existingBalance));
         when(balanceRepositoryPort.save(any(Balance.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         // when
@@ -226,7 +226,7 @@ class ChargeBalanceUseCaseTest {
                 .build();
         
         when(userRepositoryPort.findById(userId)).thenReturn(Optional.of(user));
-        when(balanceRepositoryPort.findByUserId(userId)).thenReturn(Optional.of(existingBalance));
+        when(balanceRepositoryPort.findByUser(user)).thenReturn(Optional.of(existingBalance));
         when(balanceRepositoryPort.save(any(Balance.class))).thenThrow(new BalanceException.ConcurrencyConflict());
 
         // when & then

--- a/src/test/java/kr/hhplus/be/server/unit/usecase/CreateOrderUseCaseTest.java
+++ b/src/test/java/kr/hhplus/be/server/unit/usecase/CreateOrderUseCaseTest.java
@@ -25,8 +25,13 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+
+import kr.hhplus.be.server.domain.exception.OrderException;
+import kr.hhplus.be.server.domain.exception.ProductException;
+import java.util.Collections;
 
 @DisplayName("CreateOrderUseCase 단위 테스트")
 class CreateOrderUseCaseTest {
@@ -118,11 +123,226 @@ class CreateOrderUseCaseTest {
         assertThat(result.getUser()).isEqualTo(user);
     }
 
+    @Test
+    @DisplayName("존재하지 않는 사용자로 주문 생성 시 예외 발생")
+    void createOrder_UserNotFound() {
+        // given
+        Long userId = 999L;
+        Map<Long, Integer> productQuantities = Map.of(1L, 1);
+        
+        when(userRepositoryPort.findById(userId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> createOrderUseCase.execute(userId, productQuantities))
+                .isInstanceOf(OrderException.InvalidUser.class)
+                .hasMessage("Invalid user ID");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 상품으로 주문 생성 시 예외 발생")
+    void createOrder_ProductNotFound() {
+        // given
+        Long userId = 1L;
+        Map<Long, Integer> productQuantities = Map.of(999L, 1);
+        
+        User user = User.builder()
+                .name("테스트 사용자")
+                .build();
+        
+        when(userRepositoryPort.findById(userId)).thenReturn(Optional.of(user));
+        when(productRepositoryPort.findById(999L)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> createOrderUseCase.execute(userId, productQuantities))
+                .isInstanceOf(ProductException.NotFound.class)
+                .hasMessage("Product not found");
+    }
+
+    @Test
+    @DisplayName("재고 부족 상품으로 주문 생성 시 예외 발생")
+    void createOrder_InsufficientStock() {
+        // given
+        Long userId = 1L;
+        Map<Long, Integer> productQuantities = Map.of(1L, 100); // 재고보다 많은 주문
+        
+        User user = User.builder()
+                .name("테스트 사용자")
+                .build();
+        
+        Product product = Product.builder()
+                .name("재고 부족 상품")
+                .price(new BigDecimal("10000"))
+                .stock(10) // 주문량보다 적은 재고
+                .reservedStock(0)
+                .build();
+        
+        when(userRepositoryPort.findById(userId)).thenReturn(Optional.of(user));
+        when(productRepositoryPort.findById(1L)).thenReturn(Optional.of(product));
+
+        // when & then
+        assertThatThrownBy(() -> createOrderUseCase.execute(userId, productQuantities))
+                .isInstanceOf(ProductException.OutOfStock.class)
+                .hasMessage("Product out of stock");
+    }
+
+    @Test
+    @DisplayName("빈 주문 리스트로 주문 생성 시 예외 발생")
+    void createOrder_EmptyProductList() {
+        // given
+        Long userId = 1L;
+        Map<Long, Integer> emptyProductQuantities = Collections.emptyMap();
+        
+        User user = User.builder()
+                .name("테스트 사용자")
+                .build();
+        
+        when(userRepositoryPort.findById(userId)).thenReturn(Optional.of(user));
+
+        // when & then
+        assertThatThrownBy(() -> createOrderUseCase.execute(userId, emptyProductQuantities))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Order must contain at least one item");
+    }
+
+    @Test
+    @DisplayName("null 사용자 ID로 주문 생성 시 예외 발생")
+    void createOrder_WithNullUserId() {
+        // given
+        Long userId = null;
+        Map<Long, Integer> productQuantities = Map.of(1L, 1);
+
+        // when & then
+        assertThatThrownBy(() -> createOrderUseCase.execute(userId, productQuantities))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("null 주문 리스트로 주문 생성 시 예외 발생")
+    void createOrder_WithNullProductList() {
+        // given
+        Long userId = 1L;
+        Map<Long, Integer> productQuantities = null;
+        
+        User user = User.builder()
+                .name("테스트 사용자")
+                .build();
+        
+        when(userRepositoryPort.findById(userId)).thenReturn(Optional.of(user));
+
+        // when & then
+        assertThatThrownBy(() -> createOrderUseCase.execute(userId, productQuantities))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("음수 수량으로 주문 생성 시 예외 발생")
+    void createOrder_WithNegativeQuantity() {
+        // given
+        Long userId = 1L;
+        Map<Long, Integer> productQuantities = Map.of(1L, -1); // 음수 수량
+        
+        User user = User.builder()
+                .name("테스트 사용자")
+                .build();
+        
+        Product product = Product.builder()
+                .name("상품")
+                .price(new BigDecimal("10000"))
+                .stock(10)
+                .reservedStock(0)
+                .build();
+        
+        when(userRepositoryPort.findById(userId)).thenReturn(Optional.of(user));
+        when(productRepositoryPort.findById(1L)).thenReturn(Optional.of(product));
+
+        // when & then
+        assertThatThrownBy(() -> createOrderUseCase.execute(userId, productQuantities))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Quantity must be positive");
+    }
+
+    @Test
+    @DisplayName("0 수량으로 주문 생성 시 예외 발생")
+    void createOrder_WithZeroQuantity() {
+        // given
+        Long userId = 1L;
+        Map<Long, Integer> productQuantities = Map.of(1L, 0); // 0 수량
+        
+        User user = User.builder()
+                .name("테스트 사용자")
+                .build();
+        
+        Product product = Product.builder()
+                .name("상품")
+                .price(new BigDecimal("10000"))
+                .stock(10)
+                .reservedStock(0)
+                .build();
+        
+        when(userRepositoryPort.findById(userId)).thenReturn(Optional.of(user));
+        when(productRepositoryPort.findById(1L)).thenReturn(Optional.of(product));
+
+        // when & then
+        assertThatThrownBy(() -> createOrderUseCase.execute(userId, productQuantities))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Quantity must be positive");
+    }
+
+    @Test
+    @DisplayName("대량 주문 생성 시 예외 발생")
+    void createOrder_ExcessiveQuantity() {
+        // given
+        Long userId = 1L;
+        Map<Long, Integer> productQuantities = Map.of(1L, 1000000); // 대량 주문
+        
+        User user = User.builder()
+                .name("테스트 사용자")
+                .build();
+        
+        Product product = Product.builder()
+                .name("상품")
+                .price(new BigDecimal("10000"))
+                .stock(100)
+                .reservedStock(0)
+                .build();
+        
+        when(userRepositoryPort.findById(userId)).thenReturn(Optional.of(user));
+        when(productRepositoryPort.findById(1L)).thenReturn(Optional.of(product));
+
+        // when & then
+        assertThatThrownBy(() -> createOrderUseCase.execute(userId, productQuantities))
+                .isInstanceOf(ProductException.OutOfStock.class)
+                .hasMessage("Product out of stock");
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideInvalidUserIds")
+    @DisplayName("다양한 비정상 사용자 ID로 주문 생성")
+    void createOrder_WithInvalidUserIds(Long invalidUserId) {
+        // given
+        Map<Long, Integer> productQuantities = Map.of(1L, 1);
+        
+        when(userRepositoryPort.findById(invalidUserId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> createOrderUseCase.execute(invalidUserId, productQuantities))
+                .isInstanceOf(OrderException.InvalidUser.class);
+    }
+
     private static Stream<Arguments> provideOrderData() {
         return Stream.of(
                 Arguments.of(1L, Map.of(1L, 1)), // 단일 상품
                 Arguments.of(2L, Map.of(1L, 2, 2L, 1)), // 다중 상품
                 Arguments.of(3L, Map.of(3L, 5)) // 대량 주문
+        );
+    }
+
+    private static Stream<Arguments> provideInvalidUserIds() {
+        return Stream.of(
+                Arguments.of(-1L),
+                Arguments.of(0L),
+                Arguments.of(Long.MAX_VALUE),
+                Arguments.of(Long.MIN_VALUE)
         );
     }
 } 

--- a/src/test/java/kr/hhplus/be/server/unit/usecase/GetBalanceUseCaseTest.java
+++ b/src/test/java/kr/hhplus/be/server/unit/usecase/GetBalanceUseCaseTest.java
@@ -63,7 +63,7 @@ class GetBalanceUseCaseTest {
                 .build();
         
         when(userRepositoryPort.findById(userId)).thenReturn(Optional.of(user));
-        when(balanceRepositoryPort.findByUserId(userId)).thenReturn(Optional.of(balance));
+        when(balanceRepositoryPort.findByUser(user)).thenReturn(Optional.of(balance));
 
         // when
         Optional<Balance> result = getBalanceUseCase.execute(userId);
@@ -105,7 +105,7 @@ class GetBalanceUseCaseTest {
                 .build();
         
         when(userRepositoryPort.findById(userId)).thenReturn(Optional.of(user));
-        when(balanceRepositoryPort.findByUserId(userId)).thenReturn(Optional.of(balance));
+        when(balanceRepositoryPort.findByUser(user)).thenReturn(Optional.of(balance));
 
         // when
         Optional<Balance> result = getBalanceUseCase.execute(userId);
@@ -139,7 +139,7 @@ class GetBalanceUseCaseTest {
                 .build();
         
         when(userRepositoryPort.findById(userId)).thenReturn(Optional.of(user));
-        when(balanceRepositoryPort.findByUserId(userId)).thenReturn(Optional.empty());
+        when(balanceRepositoryPort.findByUser(user)).thenReturn(Optional.empty());
 
         // when
         Optional<Balance> result = getBalanceUseCase.execute(userId);
@@ -178,7 +178,7 @@ class GetBalanceUseCaseTest {
                 .build();
         
         when(userRepositoryPort.findById(userId)).thenReturn(Optional.of(user));
-        when(balanceRepositoryPort.findByUserId(userId)).thenReturn(Optional.of(negativeBalance));
+        when(balanceRepositoryPort.findByUser(user)).thenReturn(Optional.of(negativeBalance));
 
         // when
         Optional<Balance> result = getBalanceUseCase.execute(userId);
@@ -204,7 +204,7 @@ class GetBalanceUseCaseTest {
                 .build();
         
         when(userRepositoryPort.findById(userId)).thenReturn(Optional.of(user));
-        when(balanceRepositoryPort.findByUserId(userId)).thenReturn(Optional.of(largeBalance));
+        when(balanceRepositoryPort.findByUser(user)).thenReturn(Optional.of(largeBalance));
 
         // when
         Optional<Balance> result = getBalanceUseCase.execute(userId);

--- a/src/test/java/kr/hhplus/be/server/unit/usecase/GetCouponListUseCaseTest.java
+++ b/src/test/java/kr/hhplus/be/server/unit/usecase/GetCouponListUseCaseTest.java
@@ -22,7 +22,11 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
+
+import kr.hhplus.be.server.domain.exception.CouponException;
+import java.util.Collections;
 
 @DisplayName("GetCouponListUseCase 단위 테스트")
 class GetCouponListUseCaseTest {
@@ -129,11 +133,154 @@ class GetCouponListUseCaseTest {
         // assertThat(result).isNotEmpty();
     }
 
+    @Test
+    @DisplayName("존재하지 않는 사용자 쿠폰 목록 조회 시 예외 발생")
+    void getCouponList_UserNotFound() {
+        // given
+        Long userId = 999L;
+        int limit = 10;
+        int offset = 0;
+        
+        when(userRepositoryPort.findById(userId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> getCouponListUseCase.execute(userId, limit, offset))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("User not found");
+    }
+
+    @Test
+    @DisplayName("null 사용자 ID로 쿠폰 목록 조회 시 예외 발생")
+    void getCouponList_WithNullUserId() {
+        // given
+        Long userId = null;
+        int limit = 10;
+        int offset = 0;
+
+        // when & then
+        assertThatThrownBy(() -> getCouponListUseCase.execute(userId, limit, offset))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("쿠폰이 없는 사용자 목록 조회")
+    void getCouponList_EmptyCoupons() {
+        // given
+        Long userId = 1L;
+        int limit = 10;
+        int offset = 0;
+        
+        User user = User.builder()
+                .name("쿠폰 없는 사용자")
+                .build();
+        
+        when(userRepositoryPort.findById(userId)).thenReturn(Optional.of(user));
+        when(couponHistoryRepositoryPort.findByUserId(userId, limit, offset)).thenReturn(Collections.emptyList());
+
+        // when
+        List<CouponHistory> result = getCouponListUseCase.execute(userId, limit, offset);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("비정상적인 페이지네이션 파라미터 - 음수 limit")
+    void getCouponList_WithNegativeLimit() {
+        // given
+        Long userId = 1L;
+        int limit = -1;
+        int offset = 0;
+        
+        User user = User.builder()
+                .name("테스트 사용자")
+                .build();
+        
+        when(userRepositoryPort.findById(userId)).thenReturn(Optional.of(user));
+
+        // when & then
+        assertThatThrownBy(() -> getCouponListUseCase.execute(userId, limit, offset))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("limit");
+    }
+
+    @Test
+    @DisplayName("비정상적인 페이지네이션 파라미터 - 음수 offset")
+    void getCouponList_WithNegativeOffset() {
+        // given
+        Long userId = 1L;
+        int limit = 10;
+        int offset = -1;
+        
+        User user = User.builder()
+                .name("테스트 사용자")
+                .build();
+        
+        when(userRepositoryPort.findById(userId)).thenReturn(Optional.of(user));
+
+        // when & then
+        assertThatThrownBy(() -> getCouponListUseCase.execute(userId, limit, offset))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("offset");
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideInvalidUserIds")
+    @DisplayName("다양한 비정상 사용자 ID로 쿠폰 목록 조회")
+    void getCouponList_WithInvalidUserIds(Long invalidUserId) {
+        // given
+        int limit = 10;
+        int offset = 0;
+        
+        when(userRepositoryPort.findById(invalidUserId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> getCouponListUseCase.execute(invalidUserId, limit, offset))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideInvalidPaginationParams")
+    @DisplayName("다양한 비정상 페이지네이션 파라미터")
+    void getCouponList_WithInvalidPagination(String description, int limit, int offset) {
+        // given
+        Long userId = 1L;
+        
+        User user = User.builder()
+                .name("테스트 사용자")
+                .build();
+        
+        when(userRepositoryPort.findById(userId)).thenReturn(Optional.of(user));
+
+        // when & then
+        assertThatThrownBy(() -> getCouponListUseCase.execute(userId, limit, offset))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
     private static Stream<Arguments> providePaginationData() {
         return Stream.of(
                 Arguments.of(1L, 5, 0),
                 Arguments.of(2L, 10, 5),
                 Arguments.of(3L, 20, 0)
+        );
+    }
+
+    private static Stream<Arguments> provideInvalidUserIds() {
+        return Stream.of(
+                Arguments.of(-1L),
+                Arguments.of(0L),
+                Arguments.of(Long.MAX_VALUE),
+                Arguments.of(Long.MIN_VALUE)
+        );
+    }
+
+    private static Stream<Arguments> provideInvalidPaginationParams() {
+        return Stream.of(
+                Arguments.of("음수 limit", -1, 0),
+                Arguments.of("음수 offset", 10, -1),
+                Arguments.of("0 limit", 0, 0),
+                Arguments.of("과도한 limit", 10000, 0)
         );
     }
 }

--- a/src/test/java/kr/hhplus/be/server/unit/usecase/GetCouponListUseCaseTest.java
+++ b/src/test/java/kr/hhplus/be/server/unit/usecase/GetCouponListUseCaseTest.java
@@ -85,7 +85,7 @@ class GetCouponListUseCaseTest {
         );
         
         when(userRepositoryPort.findById(userId)).thenReturn(Optional.of(user));
-        when(couponHistoryRepositoryPort.findByUserId(userId, limit, offset)).thenReturn(couponHistories);
+        when(couponHistoryRepositoryPort.findByUserWithPagination(user, limit, offset)).thenReturn(couponHistories);
 
         // when
         List<CouponHistory> result = getCouponListUseCase.execute(userId, limit, offset);
@@ -122,7 +122,7 @@ class GetCouponListUseCaseTest {
         );
         
         when(userRepositoryPort.findById(userId)).thenReturn(Optional.of(user));
-        when(couponHistoryRepositoryPort.findByUserId(userId, limit, offset)).thenReturn(couponHistories);
+        when(couponHistoryRepositoryPort.findByUserWithPagination(user, limit, offset)).thenReturn(couponHistories);
 
         // when
         List<CouponHistory> result = getCouponListUseCase.execute(userId, limit, offset);
@@ -175,7 +175,7 @@ class GetCouponListUseCaseTest {
                 .build();
         
         when(userRepositoryPort.findById(userId)).thenReturn(Optional.of(user));
-        when(couponHistoryRepositoryPort.findByUserId(userId, limit, offset)).thenReturn(Collections.emptyList());
+        when(couponHistoryRepositoryPort.findByUserWithPagination(user, limit, offset)).thenReturn(Collections.emptyList());
 
         // when
         List<CouponHistory> result = getCouponListUseCase.execute(userId, limit, offset);

--- a/src/test/java/kr/hhplus/be/server/unit/usecase/GetOrderListUseCaseTest.java
+++ b/src/test/java/kr/hhplus/be/server/unit/usecase/GetOrderListUseCaseTest.java
@@ -61,7 +61,7 @@ class GetOrderListUseCaseTest {
         );
         
         when(userRepositoryPort.findById(userId)).thenReturn(Optional.of(user));
-        when(orderRepositoryPort.findByUserId(userId)).thenReturn(orders);
+        when(orderRepositoryPort.findByUser(user)).thenReturn(orders);
 
         // when
         List<Order> result = getOrderListUseCase.execute(userId);
@@ -107,7 +107,7 @@ class GetOrderListUseCaseTest {
         );
         
         when(userRepositoryPort.findById(userId)).thenReturn(Optional.of(user));
-        when(orderRepositoryPort.findByUserId(userId)).thenReturn(orders);
+        when(orderRepositoryPort.findByUser(user)).thenReturn(orders);
 
         // when
         List<Order> result = getOrderListUseCase.execute(userId);

--- a/src/test/java/kr/hhplus/be/server/unit/usecase/GetProductListUseCaseTest.java
+++ b/src/test/java/kr/hhplus/be/server/unit/usecase/GetProductListUseCaseTest.java
@@ -53,7 +53,7 @@ class GetProductListUseCaseTest {
                 createProduct(3L, "태블릿", "600000", 30)
         );
         
-        when(productRepositoryPort.findAll(limit, offset)).thenReturn(products);
+        when(productRepositoryPort.findAllWithPagination(limit, offset)).thenReturn(products);
 
         // when
         List<Product> result = getProductListUseCase.execute(limit, offset);
@@ -73,7 +73,7 @@ class GetProductListUseCaseTest {
                 createProduct(2L, "상품2", "200000", 20)
         );
         
-        when(productRepositoryPort.findAll(limit, offset)).thenReturn(products);
+        when(productRepositoryPort.findAllWithPagination(limit, offset)).thenReturn(products);
 
         // when
         List<Product> result = getProductListUseCase.execute(limit, offset);
@@ -115,7 +115,7 @@ class GetProductListUseCaseTest {
         int limit = 10;
         int offset = 0;
         
-        when(productRepositoryPort.findAll(limit, offset)).thenReturn(Collections.emptyList());
+        when(productRepositoryPort.findAllWithPagination(limit, offset)).thenReturn(Collections.emptyList());
 
         // when
         List<Product> result = getProductListUseCase.execute(limit, offset);
@@ -154,7 +154,7 @@ class GetProductListUseCaseTest {
         int limit = 10;
         int largeOffset = 999999;
         
-        when(productRepositoryPort.findAll(limit, largeOffset)).thenReturn(Collections.emptyList());
+        when(productRepositoryPort.findAllWithPagination(limit, largeOffset)).thenReturn(Collections.emptyList());
 
         // when
         List<Product> result = getProductListUseCase.execute(limit, largeOffset);

--- a/src/test/java/kr/hhplus/be/server/unit/usecase/GetProductListUseCaseTest.java
+++ b/src/test/java/kr/hhplus/be/server/unit/usecase/GetProductListUseCaseTest.java
@@ -18,7 +18,10 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
+
+import java.util.Collections;
 
 @DisplayName("GetProductListUseCase 단위 테스트")
 class GetProductListUseCaseTest {
@@ -84,6 +87,98 @@ class GetProductListUseCaseTest {
                 Arguments.of(5, 0), // 첫 페이지
                 Arguments.of(10, 10), // 두 번째 페이지
                 Arguments.of(20, 0) // 큰 페이지 크기
+        );
+    }
+
+    @Test
+    @DisplayName("비정상적인 페이지네이션 파라미터 - 음수 limit")
+    void getProducts_WithNegativeLimit() {
+        // when & then
+        assertThatThrownBy(() -> getProductListUseCase.execute(-1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("limit");
+    }
+
+    @Test
+    @DisplayName("비정상적인 페이지네이션 파라미터 - 음수 offset")
+    void getProducts_WithNegativeOffset() {
+        // when & then
+        assertThatThrownBy(() -> getProductListUseCase.execute(10, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("offset");
+    }
+
+    @Test
+    @DisplayName("빈 상품 목록 조회")
+    void getProducts_EmptyList() {
+        // given
+        int limit = 10;
+        int offset = 0;
+        
+        when(productRepositoryPort.findAll(limit, offset)).thenReturn(Collections.emptyList());
+
+        // when
+        List<Product> result = getProductListUseCase.execute(limit, offset);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("0 limit으로 상품 목록 조회")
+    void getProducts_WithZeroLimit() {
+        // when & then
+        assertThatThrownBy(() -> getProductListUseCase.execute(0, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("limit must be positive");
+    }
+
+    @Test
+    @DisplayName("과도한 limit으로 상품 목록 조회")
+    void getProducts_WithExcessiveLimit() {
+        // given
+        int excessiveLimit = 10000;
+        int offset = 0;
+
+        // when & then
+        assertThatThrownBy(() -> getProductListUseCase.execute(excessiveLimit, offset))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("limit exceeds maximum allowed");
+    }
+
+    @Test
+    @DisplayName("대량 offset으로 상품 목록 조회")
+    void getProducts_WithLargeOffset() {
+        // given
+        int limit = 10;
+        int largeOffset = 999999;
+        
+        when(productRepositoryPort.findAll(limit, largeOffset)).thenReturn(Collections.emptyList());
+
+        // when
+        List<Product> result = getProductListUseCase.execute(limit, largeOffset);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result).isEmpty();
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideInvalidPaginationParams")
+    @DisplayName("다양한 비정상 페이지네이션 파라미터")
+    void getProducts_WithInvalidPagination(String description, int limit, int offset) {
+        // when & then
+        assertThatThrownBy(() -> getProductListUseCase.execute(limit, offset))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private static Stream<Arguments> provideInvalidPaginationParams() {
+        return Stream.of(
+                Arguments.of("음수 limit", -1, 0),
+                Arguments.of("음수 offset", 10, -1),
+                Arguments.of("0 limit", 0, 0),
+                Arguments.of("과도한 limit", 10000, 0)
         );
     }
 

--- a/src/test/java/kr/hhplus/be/server/unit/usecase/GetProductUseCaseTest.java
+++ b/src/test/java/kr/hhplus/be/server/unit/usecase/GetProductUseCaseTest.java
@@ -18,7 +18,10 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
+
+import kr.hhplus.be.server.domain.exception.ProductException;
 
 @DisplayName("GetProductUseCase 단위 테스트")
 class GetProductUseCaseTest {
@@ -100,11 +103,148 @@ class GetProductUseCaseTest {
         // assertThat(result.get().getName()).isEqualTo(name);
     }
 
+    @Test
+    @DisplayName("null 상품 ID로 조회 시 예외 발생")
+    void getProduct_WithNullProductId() {
+        // given
+        Long productId = null;
+
+        // when & then
+        assertThatThrownBy(() -> getProductUseCase.execute(productId))
+                .isInstanceOf(ProductException.NotFound.class)
+                .hasMessage("Product not found");
+    }
+
+    @Test
+    @DisplayName("재고가 0인 상품 조회")
+    void getProduct_OutOfStock() {
+        // given
+        Long productId = 1L;
+        
+        Product outOfStockProduct = Product.builder()
+                .name("품절 상품")
+                .price(new BigDecimal("100000"))
+                .stock(0)
+                .reservedStock(0)
+                .build();
+        
+        when(productRepositoryPort.findById(productId)).thenReturn(Optional.of(outOfStockProduct));
+
+        // when
+        Optional<Product> result = getProductUseCase.execute(productId);
+
+        // then - TODO 구현이 완료되면 실제 검증 로직 추가
+        // assertThat(result).isPresent();
+        // assertThat(result.get().getStock()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("예약 재고가 실제 재고보다 많은 상품")
+    void getProduct_InvalidReservedStock() {
+        // given
+        Long productId = 1L;
+        
+        Product invalidProduct = Product.builder()
+                .name("비정상 상품")
+                .price(new BigDecimal("50000"))
+                .stock(10)
+                .reservedStock(15) // 재고보다 많은 예약
+                .build();
+        
+        when(productRepositoryPort.findById(productId)).thenReturn(Optional.of(invalidProduct));
+
+        // when
+        Optional<Product> result = getProductUseCase.execute(productId);
+
+        // then - TODO 구현이 완료되면 실제 검증 로직 추가
+        // assertThat(result).isPresent();
+        // assertThat(result.get().getReservedStock()).isGreaterThan(result.get().getStock());
+    }
+
+    @Test
+    @DisplayName("음수 가격을 가진 상품")
+    void getProduct_WithNegativePrice() {
+        // given
+        Long productId = 1L;
+        
+        Product negativeProduct = Product.builder()
+                .name("음수 가격 상품")
+                .price(new BigDecimal("-10000"))
+                .stock(10)
+                .reservedStock(0)
+                .build();
+        
+        when(productRepositoryPort.findById(productId)).thenReturn(Optional.of(negativeProduct));
+
+        // when
+        Optional<Product> result = getProductUseCase.execute(productId);
+
+        // then - TODO 구현이 완료되면 실제 검증 로직 추가
+        // assertThat(result).isPresent();
+        // assertThat(result.get().getPrice()).isEqualTo(new BigDecimal("-10000"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideInvalidProductIds")
+    @DisplayName("다양한 비정상 상품 ID로 조회")
+    void getProduct_WithInvalidProductIds(Long invalidProductId) {
+        // given
+        when(productRepositoryPort.findById(invalidProductId)).thenReturn(Optional.empty());
+
+        // when
+        Optional<Product> result = getProductUseCase.execute(invalidProductId);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideEdgeCaseProducts")
+    @DisplayName("극한값 상품 데이터로 조회")
+    void getProduct_WithEdgeCaseData(String description, String price, int stock, int reservedStock) {
+        // given
+        Long productId = 1L;
+        
+        Product edgeCaseProduct = Product.builder()
+                .name("극한값 " + description)
+                .price(new BigDecimal(price))
+                .stock(stock)
+                .reservedStock(reservedStock)
+                .build();
+        
+        when(productRepositoryPort.findById(productId)).thenReturn(Optional.of(edgeCaseProduct));
+
+        // when
+        Optional<Product> result = getProductUseCase.execute(productId);
+
+        // then - TODO 구현이 완료되면 실제 검증 로직 추가
+        // assertThat(result).isPresent();
+        // assertThat(result.get().getPrice()).isEqualTo(new BigDecimal(price));
+    }
+
     private static Stream<Arguments> provideProductData() {
         return Stream.of(
                 Arguments.of(1L, "노트북", "1200000"),
                 Arguments.of(2L, "스마트폰", "800000"),
                 Arguments.of(3L, "태블릿", "600000")
+        );
+    }
+
+    private static Stream<Arguments> provideInvalidProductIds() {
+        return Stream.of(
+                Arguments.of(-1L),
+                Arguments.of(0L),
+                Arguments.of(Long.MAX_VALUE),
+                Arguments.of(Long.MIN_VALUE)
+        );
+    }
+
+    private static Stream<Arguments> provideEdgeCaseProducts() {
+        return Stream.of(
+                Arguments.of("무료 상품", "0", 100, 0),
+                Arguments.of("최대 가격", "999999999", 1, 0),
+                Arguments.of("음수 재고", "50000", -10, 0),
+                Arguments.of("전체 예약", "30000", 100, 100)
         );
     }
 }

--- a/src/test/java/kr/hhplus/be/server/unit/usecase/PayOrderUseCaseTest.java
+++ b/src/test/java/kr/hhplus/be/server/unit/usecase/PayOrderUseCaseTest.java
@@ -2,6 +2,7 @@ package kr.hhplus.be.server.unit.usecase;
 
 import kr.hhplus.be.server.domain.entity.Payment;
 import kr.hhplus.be.server.domain.entity.Order;
+import kr.hhplus.be.server.domain.entity.User;
 import kr.hhplus.be.server.domain.port.storage.OrderRepositoryPort;
 import kr.hhplus.be.server.domain.port.storage.PaymentRepositoryPort;
 import kr.hhplus.be.server.domain.port.storage.EventLogRepositoryPort;
@@ -22,8 +23,12 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+
+import kr.hhplus.be.server.domain.exception.PaymentException;
+import kr.hhplus.be.server.domain.exception.BalanceException;
 
 @DisplayName("PayOrderUseCase 단위 테스트")
 class PayOrderUseCaseTest {
@@ -97,11 +102,202 @@ class PayOrderUseCaseTest {
         assertThat(result.getOrder()).isEqualTo(order);
     }
 
+    @Test
+    @DisplayName("존재하지 않는 주문 결제 시 예외 발생")
+    void payOrder_OrderNotFound() {
+        // given
+        Long orderId = 999L;
+        Long userId = 1L;
+        Long couponId = null;
+        
+        when(orderRepositoryPort.findById(orderId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> payOrderUseCase.execute(orderId, userId, couponId))
+                .isInstanceOf(PaymentException.OrderNotFound.class)
+                .hasMessage("Order not found");
+    }
+
+    @Test
+    @DisplayName("다른 사용자의 주문 결제 시 예외 발생")
+    void payOrder_UnauthorizedAccess() {
+        // given
+        Long orderId = 1L;
+        Long userId = 1L;
+        Long actualUserId = 2L; // 다른 사용자
+        Long couponId = null;
+        
+        User actualUser = User.builder()
+                .name("다른 사용자")
+                .build();
+        
+        Order order = Order.builder()
+                .user(actualUser) // 다른 사용자의 주문
+                .totalAmount(new BigDecimal("100000"))
+                .build();
+        
+        when(orderRepositoryPort.findById(orderId)).thenReturn(Optional.of(order));
+
+        // when & then
+        assertThatThrownBy(() -> payOrderUseCase.execute(orderId, userId, couponId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unauthorized");
+    }
+
+    @Test
+    @DisplayName("잘못된 쿠폰 ID로 결제 시 예외 발생")
+    void payOrder_InvalidCoupon() {
+        // given
+        Long orderId = 1L;
+        Long userId = 1L;
+        Long couponId = 999L; // 존재하지 않는 쿠폰
+        
+        User user = User.builder()
+                .name("테스트 사용자")
+                .build();
+        
+        Order order = Order.builder()
+                .user(user)
+                .totalAmount(new BigDecimal("100000"))
+                .build();
+        
+        when(orderRepositoryPort.findById(orderId)).thenReturn(Optional.of(order));
+
+        // when & then
+        assertThatThrownBy(() -> payOrderUseCase.execute(orderId, userId, couponId))
+                .isInstanceOf(PaymentException.InvalidCoupon.class)
+                .hasMessage("Invalid coupon ID");
+    }
+
+    @Test
+    @DisplayName("잔액 부족으로 결제 시 예외 발생")
+    void payOrder_InsufficientBalance() {
+        // given
+        Long orderId = 1L;
+        Long userId = 1L;
+        Long couponId = null;
+        
+        User user = User.builder()
+                .name("테스트 사용자")
+                .build();
+        
+        Order order = Order.builder()
+                .user(user)
+                .totalAmount(new BigDecimal("100000"))
+                .build();
+        
+        when(orderRepositoryPort.findById(orderId)).thenReturn(Optional.of(order));
+        when(paymentRepositoryPort.save(any(Payment.class))).thenThrow(new PaymentException.InsufficientBalance());
+
+        // when & then
+        assertThatThrownBy(() -> payOrderUseCase.execute(orderId, userId, couponId))
+                .isInstanceOf(PaymentException.InsufficientBalance.class)
+                .hasMessage("Insufficient balance");
+    }
+
+    @Test
+    @DisplayName("동시성 충돌로 결제 시 예외 발생")
+    void payOrder_ConcurrencyConflict() {
+        // given
+        Long orderId = 1L;
+        Long userId = 1L;
+        Long couponId = null;
+        
+        User user = User.builder()
+                .name("테스트 사용자")
+                .build();
+        
+        Order order = Order.builder()
+                .user(user)
+                .totalAmount(new BigDecimal("100000"))
+                .build();
+        
+        when(orderRepositoryPort.findById(orderId)).thenReturn(Optional.of(order));
+        when(paymentRepositoryPort.save(any(Payment.class))).thenThrow(new PaymentException.ConcurrencyConflict());
+
+        // when & then
+        assertThatThrownBy(() -> payOrderUseCase.execute(orderId, userId, couponId))
+                .isInstanceOf(PaymentException.ConcurrencyConflict.class)
+                .hasMessage("Concurrent payment conflict");
+    }
+
+    @Test
+    @DisplayName("null 주문 ID로 결제 시 예외 발생")
+    void payOrder_WithNullOrderId() {
+        // given
+        Long orderId = null;
+        Long userId = 1L;
+        Long couponId = null;
+
+        // when & then
+        assertThatThrownBy(() -> payOrderUseCase.execute(orderId, userId, couponId))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("null 사용자 ID로 결제 시 예외 발생")
+    void payOrder_WithNullUserId() {
+        // given
+        Long orderId = 1L;
+        Long userId = null;
+        Long couponId = null;
+
+        // when & then
+        assertThatThrownBy(() -> payOrderUseCase.execute(orderId, userId, couponId))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("비정상적인 주문 상태로 결제 시 예외 발생")
+    void payOrder_InvalidOrderStatus() {
+        // given
+        Long orderId = 1L;
+        Long userId = 1L;
+        Long couponId = null;
+        
+        User user = User.builder()
+                .name("테스트 사용자")
+                .build();
+        
+        Order order = Order.builder()
+                .user(user)
+                .totalAmount(new BigDecimal("100000"))
+                .build();
+        
+        when(orderRepositoryPort.findById(orderId)).thenReturn(Optional.of(order));
+        when(paymentRepositoryPort.save(any(Payment.class))).thenThrow(new PaymentException.InvalidOrderStatus());
+
+        // when & then
+        assertThatThrownBy(() -> payOrderUseCase.execute(orderId, userId, couponId))
+                .isInstanceOf(PaymentException.InvalidOrderStatus.class)
+                .hasMessage("Order status not eligible for payment");
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideInvalidIds")
+    @DisplayName("비정상 ID 값들로 결제 테스트")
+    void payOrder_WithInvalidIds(Long orderId, Long userId) {
+        // when & then
+        assertThatThrownBy(() -> payOrderUseCase.execute(orderId, userId, null))
+                .isInstanceOf(RuntimeException.class);
+    }
+
     private static Stream<Arguments> providePaymentData() {
         return Stream.of(
                 Arguments.of(1L, 1L, 1L), // 쿠폰 사용
                 Arguments.of(2L, 2L, null), // 쿠폰 미사용
                 Arguments.of(3L, 3L, 2L) // 다른 쿠폰 사용
+        );
+    }
+
+    private static Stream<Arguments> provideInvalidIds() {
+        return Stream.of(
+                Arguments.of(-1L, 1L),
+                Arguments.of(1L, -1L),
+                Arguments.of(0L, 1L),
+                Arguments.of(1L, 0L),
+                Arguments.of(Long.MAX_VALUE, 1L),
+                Arguments.of(1L, Long.MAX_VALUE)
         );
     }
 } 


### PR DESCRIPTION
[feat: Balance, Coupon, Order, ProductController에서 비즈니스 로직 구현](https://github.com/Jang-zn/hhp-main/commit/e19f688c7bfd25749379216132a87c1eba318b8f) 

[test: InMemoryBalance, Coupon, Product 저장소에 대한 예외 처리 및 극한값 테스트 추가](https://github.com/Jang-zn/hhp-main/commit/b13df98e08c8b9dc8d1b7f8592d7baa6a0bfc3b0) 

[test: BalanceController 및 OrderController 단위 테스트 개선](https://github.com/Jang-zn/hhp-main/commit/73189d38a5e9c124d8c6846cb1ed2f3902690814) 

[test: AcquireCoupon, ChargeBalance, CreateOrder, GetBalance, GetCoupo…](https://github.com/Jang-zn/hhp-main/commit/ccb71f1f1e621805925f00517a99d53c54f17900) 

[refactor: BalanceChargeRequest, CreateOrderRequest 삭제 및 BalanceReques…](https://github.com/Jang-zn/hhp-main/commit/5084850e763b2d581d0667c8f92655038cfec670) 

[test: AcquireCoupon, ChargeBalance, GetBalance, GetCouponList, GetPro…](https://github.com/Jang-zn/hhp-main/commit/06037b2d98a0c5bc7e07c58738e03066c7f20432) 

[refactor: 엔티티 클래스에서](https://github.com/Jang-zn/hhp-main/commit/cbc4dd4880140b80ed9876d52d75a0d5f1ea2a8c) @builder[를](https://github.com/Jang-zn/hhp-main/commit/cbc4dd4880140b80ed9876d52d75a0d5f1ea2a8c) @SuperBuilder[로 변경 및 메서드 추가](https://github.com/Jang-zn/hhp-main/commit/cbc4dd4880140b80ed9876d52d75a0d5f1ea2a8c) 

[refactor: CachePort 및 저장소 포트 인터페이스 수정](https://github.com/Jang-zn/hhp-main/commit/f17f357386d08a427e8302a5e4b82db14e06c73b) 

[refactor: InMemory 저장소 및 CachePort 인터페이스 수정](https://github.com/Jang-zn/hhp-main/commit/cb1aa7ce9a900ce9d25fe92acbea925b537ca15e) 

[refactor: BalanceChargeRequest 및 CreateOrderRequest를 BalanceRequest 및…](https://github.com/Jang-zn/hhp-main/commit/dc896e2600aeef30bb3f5a5b356cac9b3cad0f39) 

[test: InMemory 저장소 테스트 메서드 이름 변경 및 사용자 객체 사용으로 수정](https://github.com/Jang-zn/hhp-main/commit/dc9f8b6365207876f3d79745cfd83736902fdc4b) 

[feat: ChargeBalance, GetBalance, AcquireCoupon, GetCouponList, Create…](https://github.com/Jang-zn/hhp-main/commit/cc29b9d657527a131bc53927d04ce33e6bb05231)